### PR TITLE
4.1 Update: Change backed-up ini files to be .txt

### DIFF
--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -27,7 +27,7 @@ https://www.youtube.com/watch?v=29FM0GywcWA
 ### Update for merged mods
 For merged mods, run the script wherever the `merged.ini` file is located.
 
-### Options
+### Command Options
 ```
   -h, --help          show this help message and exit
   -d, --deleteBackup  whether to keep a backup copy of the original .ini files

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -26,3 +26,9 @@ https://www.youtube.com/watch?v=29FM0GywcWA
 
 ### Update for merged mods
 For merged mods, run the script wherever the `merged.ini` file is located.
+
+### Options
+```
+  -h, --help          show this help message and exit
+  -d, --deleteBackup  whether to keep a backup copy of the original .ini files
+```

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -30,5 +30,5 @@ For merged mods, run the script wherever the `merged.ini` file is located.
 ### Command Options
 ```
   -h, --help          show this help message and exit
-  -d, --deleteBackup  whether to keep a backup copy of the original .ini files
+  -d, --deleteBackup  whether to not keep a backup copy of the original .ini files
 ```

--- a/Fix-Raiden-Boss 2.0 (for all user )/RaidenBossFix2.py
+++ b/Fix-Raiden-Boss 2.0 (for all user )/RaidenBossFix2.py
@@ -494,6 +494,8 @@ class IniFile():
             if (not beforeOriginal):
                 f.write(addition)
 
+        self._isRaidenFixed = True
+
     def fixBase(self, remapBlendModel: RemapBlendModel, logger: Optional[Logger] = None, keepBackup: bool = True):
         addFix = self.getBaseFixStr(remapBlendModel.fixedBlendName, remapBlendModel.draw)
         self.injectAddition(addFix, logger = logger, keepBackup = keepBackup)


### PR DESCRIPTION
The previous backup method of using a `DISABLED.ini` file may affect other mod scripts that try to check whether a mod only has a single `.ini` file

Also added feature of whether to keep the original `.ini` files since mods are becoming very messy with many other scripts saving their own copies of backups