### PR TITLE
Add undo fix feature

### DIFF
--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -16,7 +16,7 @@
 python RaidenBossFix2.py
 ```
 then enter
-- make sure you only run it 1 time
+- **RECOMMENDED** that you only run **1 TIME** (There are command options to undo your run if needed...)
 ### STEP 3:
 - Open the game and enjoy it
 ### VIDEO TUTORIAL AND EXAMPLES:
@@ -30,5 +30,7 @@ For merged mods, run the script wherever the `merged.ini` file is located.
 ### Command Options
 ```
   -h, --help          show this help message and exit
-  -d, --deleteBackup  whether to not keep a backup copy of the original .ini files
+  -d, --deleteBackup  deletes backup copies of the original .ini files
+  -f, --fixOnly       only fixes the mod without cleaning any previous runs of the script
+  -r, --revert        reverts back previous runs of the script
 ```

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -17,7 +17,7 @@ python RaidenBossFix2.py
 ```
 then enter
 - **RECOMMENDED** that you only run **1 TIME** 
-*(By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option if you only want to undo previous runs without adding any new changes added)*
+*(By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option if you only want to undo previous runs without adding any new changes)*
 ### STEP 3:
 - Open the game and enjoy it
 ### VIDEO TUTORIAL AND EXAMPLES:

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -16,7 +16,8 @@
 python RaidenBossFix2.py
 ```
 then enter
-- **RECOMMENDED** that you only run **1 TIME** (By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option)
+- **RECOMMENDED** that you only run **1 TIME** 
+*(By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option)*
 ### STEP 3:
 - Open the game and enjoy it
 ### VIDEO TUTORIAL AND EXAMPLES:

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -17,7 +17,7 @@ python RaidenBossFix2.py
 ```
 then enter
 - **RECOMMENDED** that you only run **1 TIME** 
-*(By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option)*
+*(By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option if you do not want any new changes added)*
 ### STEP 3:
 - Open the game and enjoy it
 ### VIDEO TUTORIAL AND EXAMPLES:

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -17,7 +17,7 @@ python RaidenBossFix2.py
 ```
 then enter
 - **RECOMMENDED** that you only run **1 TIME** 
-*(By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option if you do not want any new changes added)*
+*(By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option if you only want to undo previous runs without adding any new changes added)*
 ### STEP 3:
 - Open the game and enjoy it
 ### VIDEO TUTORIAL AND EXAMPLES:

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -16,7 +16,7 @@
 python RaidenBossFix2.py
 ```
 then enter
-- **RECOMMENDED** that you only run **1 TIME** (There are command options to undo your run if needed...)
+- **RECOMMENDED** that you only run **1 TIME** (By default, the script undos changes from previous runs before adding new changes or you can explicitely add the `--revert` option)
 ### STEP 3:
 - Open the game and enjoy it
 ### VIDEO TUTORIAL AND EXAMPLES:


### PR DESCRIPTION
Users do not have to go to every folder and manually delete/change
files before they rerun the script in case their first run failed

By default, when the user clicks on the script or runs the program on
CLI without arguments, the script undo changes from previous runs, then
adds its new changes.

From this feature, added options of whether to undo without any fix
or vice versa (fix without any undo)

### Note:
Since the modified `.ini` language used for mods is a CFG (context free grammar), using
Regex is not the best solution for parsing. But the parsing in the undo feature would be fine for general use cases.