### PR TITLE
Add CI/CD for PyPI Package on New Release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,6 +26,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
+    - name: Check Directory
+      run: >-
+        ls
     - name: Navigate to Package Directory
       run: >- 
         cd 'Fix-Raiden-Boss 2.0 (for all user )'

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,24 +26,13 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
-    - name: Check Directory
-      run: >-
-        ls
-    - name: Navigate to Package Directory
-      run: >- 
-        cd *2*
-    - name: Check Path
-      run: >-
-        pwd
-    - name: Check Children
-      run: >-
-        ls
     - name: Install pypa/build
       run: >-
         python3 -m
         pip install
         build
         --user
+      working-directory: './Fix-Raiden-Boss 2.0 (for all user )'
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -32,14 +32,14 @@ jobs:
         pip install
         build
         --user
-      working-directory: './Fix-Raiden-Boss 2.0 (for all user )'
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
+      working-directory: './Fix-Raiden-Boss 2.0 (for all user )'
     - name: Store the distribution packages
       uses: actions/upload-artifact@v3
       with:
         name: python-package-distributions
-        path: dist/
+        path: 'Fix-Raiden-Boss 2.0 (for all user )/dist/'
 
   publish-to-pypi:
     name: >-

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,62 @@
+# This workflow will upload a Python Package using Twine when a release is created
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python#publishing-to-package-registries
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Upload FixRaidenBoss2 Package
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.x"
+    - name: Install pypa/build
+      run: >-
+        python3 -m
+        pip install
+        build
+        --user
+    - name: Build a binary wheel and a source tarball
+      run: python3 -m build
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+
+  publish-to-pypi:
+    name: >-
+      Publish FixRaidenBoss2 Package to PyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/FixRaidenBoss2  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v3
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,6 +26,9 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: "3.x"
+    - name: Navigate to Package Directory
+      run: >- 
+        cd 'Fix-Raiden-Boss 2.0 (for all user )'
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -31,7 +31,13 @@ jobs:
         ls
     - name: Navigate to Package Directory
       run: >- 
-        cd 'Fix-Raiden-Boss 2.0 (for all user )'
+        cd *2*
+    - name: Check Path
+      run: >-
+        pwd
+    - name: Check Children
+      run: >-
+        ls
     - name: Install pypa/build
       run: >-
         python3 -m

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -30,7 +30,7 @@ For merged mods, run the script wherever the `merged.ini` file is located.
 
 ## Let's Start !
 ### STEP 1:
-- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/RaidenBossFix2.py) script into Raiden Mod Folder 
+- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py) script into Raiden Mod Folder 
 ### STEP 2:
 - Double click on the script
   
@@ -56,7 +56,7 @@ then enter
 
 ## Run on CMD With a Script
 ### STEP 1:
-- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/RaidenBossFix2.py) script into Raiden Mod Folder 
+- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py) script into Raiden Mod Folder 
 
 ### STEP 2:
 [open cmd](https://www.google.com/search?q=how+to+open+cmd+in+a+folder&oq=how+to+open+cmd) and type

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -48,7 +48,7 @@ python -m pip install -U FixRaidenBoss2
 then enter
 
 ### STEP 2:
-go to your mod folder and type:
+go to your mod folder and in [cmd](https://www.google.com/search?q=how+to+open+cmd+in+a+folder&oq=how+to+open+cmd) type:
 ```python
 python -m FixRaidenBoss2
 ```

--- a/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
+++ b/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "3.2.2"
+version = "3.2.3"
 authors = [
   {name="nhok0169", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}


### PR DESCRIPTION
Used **Github Actions** to automate building the package to **Pypi**. 

Currently the action is triggered when a new version release has been made, but we could later change it to some other Github event (eg. push on some specific tag).