### PR TITLE
Add basic api

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@ body:
           required: true
         - label: I have searched [issues on Github](https://github.com/nhok0169/Fix-Raiden-Boss/issues) including closed ones and [issues on the mod site](https://gamebanana.com/tuts/15633) for similar issues. DO NOT post duplicates.
           required: true
-        - label: I included the entire log [(as a screenshot or text)](https://gist.github.com/NawalJAhmed/2168f7659c08b6a033e7f6daf8db69a6) of my run of the fix
+        - label: I included the entire log [(as a screenshot or text)](https://gist.github.com/NawalJAhmed/2168f7659c08b6a033e7f6daf8db69a6) of my run of the fix or I included the `RSFixLog.txt` file if I ran the fix using the `-l` option
           required: true
         - label: I included the `merged.ini` file if I am using merged mods or I included the whatever generated `.ini` file if I am using individual mods
           required: true

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -135,6 +135,7 @@ else:
 
 ```
 Starting to fix mod...
+Creating log file, RSFixLog.txt
 The fix failed because there is a duplicate .ini file... :(
 ```
 </details>

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -91,6 +91,7 @@ then enter
 
 Tool developpers can now include the fix within their code.
 
+### Example of Successfull Run
 ```python
 import FixRaidenBoss2 as FRB
 
@@ -108,6 +109,33 @@ print("The Raiden Mod is fixed!")
 ```
 Creating log file, RSFixLog.txt
 The Raiden Mod is fixed!
+```
+</details>
+<br>
+
+### Example of Handling Errors
+```python
+import FixRaidenBoss2 as FRB
+
+raidenBossFixService = FRB.RaidenBossFixService(path = r"my raiden folder path that contains a duplicate .ini file", log = True, verbose = False)
+
+print("Starting to fix mod...")
+try:
+    raidenBossFixService.fix()
+except FRB.DuplicateFileException as e:
+    print("The fix failed because there is a duplicate .ini file... :(")
+else:
+    print("The Raiden Mod is fixed!")
+```
+<br>
+
+<details>
+<summary>Example Result</summary>
+<br>
+
+```
+Starting to fix mod...
+The fix failed because there is a duplicate .ini file... :(
 ```
 </details>
 <br>

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -102,7 +102,7 @@ print("The Raiden Mod is fixed!")
 <br>
 
 <details>
-<summary>Result</summary>
+<summary>Example Result</summary>
 <br>
 
 ```
@@ -110,5 +110,6 @@ Creating log file, RSFixLog.txt
 The Raiden Mod is fixed!
 ```
 </details>
+<br>
 
 More info [here](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py)

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -75,11 +75,38 @@ then enter
 ## Command Options
 ```
   -h, --help           show this help message and exit
+  -s str, --src str    The path to the Raiden mod folder. If this option is not specified, then will use the current
+                       directory as the mod folder.
   -d, --deleteBackup   deletes backup copies of the original .ini files
   -f, --fixOnly        only fixes the mod without cleaning any previous runs of the script
   -r, --revert         reverts back previous runs of the script
-  -m, --manualDisable  goes into an error when duplicate .ini or Blend.buf are found in a mod
-                       instead of choosing which file you want to use
-  -p, --purgeDups      deletes unused duplicate .ini or Blend.buf instead of keeping a disabled
-                       backup copy of those files
+  -m, --manualDisable  goes into an error when duplicate .ini or Blend.buf are found in a mod instead of choosing
+                       which file you want to use
+  -p, --purgeDups      deletes unused duplicate .ini or Blend.buf instead of keeping a disabled backup copy of those
+                       files
+  -l, --log            Logs the printed out log into the RSFixLog.txt file
 ```
+
+## API Usage
+
+Tool developpers can now include the fix within their code.
+
+```python
+import FixRaidenBoss2 as FRB
+
+raidenBossFixService = FRB.RaidenBossFixService(path = r"my raiden folder path", log = True, verbose = False)
+raidenBossFixService.fix()
+
+print("The Raiden Mod is fixed!")
+```
+
+<details>
+<summary>Result</summary>
+<br>
+```
+Creating log file, RSFixLog.txt
+The Raiden Mod is fixed!
+```
+</details>
+
+More info [here](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py)

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -99,10 +99,12 @@ raidenBossFixService.fix()
 
 print("The Raiden Mod is fixed!")
 ```
+<br>
 
 <details>
 <summary>Result</summary>
 <br>
+
 ```
 Creating log file, RSFixLog.txt
 The Raiden Mod is fixed!

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -91,6 +91,15 @@ then enter
 
 Tool developpers can now include the fix within their code.
 
+<br>
+
+*Make sure you first install the module by typing into [cmd](https://www.google.com/search?q=how+to+open+cmd+in+a+folder&oq=how+to+open+cmd):*
+```bash
+python -m pip install -U FixRaidenBoss2
+```
+
+<br>
+
 ### Example of Successful Run
 ```python
 import FixRaidenBoss2 as FRB

--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -91,7 +91,7 @@ then enter
 
 Tool developpers can now include the fix within their code.
 
-### Example of Successfull Run
+### Example of Successful Run
 ```python
 import FixRaidenBoss2 as FRB
 

--- a/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
+++ b/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "3.2.5"
+version = "3.2.6"
 authors = [
   {name="nhok0169", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
+++ b/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "3.2.6"
+version = "3.2.7"
 authors = [
   {name="nhok0169", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py
+++ b/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py
@@ -1036,7 +1036,7 @@ class Mod(Model):
 
 class RaidenBossFixService():
     def __init__(self, path: Optional[str] = None, keepBackups: bool = True, fixOnly: bool = False, undoOnly: bool = False, 
-                 disableDups: bool = True, purgeDups: bool = False, log: bool = False, verbose: bool = True):
+                 disableDups: bool = False, purgeDups: bool = False, log: bool = False, verbose: bool = True, handleExceptions: bool = False):
         self.log = log
         self._loggerBasePrefix = ""
         self.logger = Logger(logTxt = log, verbose = verbose)
@@ -1047,6 +1047,7 @@ class RaidenBossFixService():
         self.disableDups = disableDups
         self.purgeDups = purgeDups
         self.verbose = verbose
+        self.handleExceptions = handleExceptions
         self._skippedMods: Dict[str, Error] = {}
         self._logFile = FileService.parseOSPath(ntpath.join(DefaultPath, LogFile))
         self._pathIsCwd = False
@@ -1384,7 +1385,10 @@ class RaidenBossFixService():
         try:
             self._fix()
         except BaseException as e:
-            self.logger.handleException(e)
+            if (self.handleExceptions):
+                self.logger.handleException(e)
+            else:
+                raise e from e
         else:
             self.logger.split()
 
@@ -1397,7 +1401,8 @@ class RaidenBossFixService():
 def main():
     args = argParser.parse_args()
     raidenBossFixService = RaidenBossFixService(path = args.src, keepBackups = not args.deleteBackup, fixOnly = args.fixOnly, 
-                                                undoOnly = args.revert, disableDups = not args.manualDisable, purgeDups = args.purgeDups, log = args.log, verbose = True)
+                                                undoOnly = args.revert, disableDups = not args.manualDisable, purgeDups = args.purgeDups, 
+                                                log = args.log, verbose = True, handleExceptions = True)
     raidenBossFixService.fix()
     raidenBossFixService.logger.waitExit()
 

--- a/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py
+++ b/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py
@@ -1388,6 +1388,7 @@ class RaidenBossFixService():
             if (self.handleExceptions):
                 self.logger.handleException(e)
             else:
+                self.createLog()
                 raise e from e
         else:
             self.logger.split()

--- a/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/__init__.py
+++ b/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/__init__.py
@@ -1,6 +1,3 @@
-from .FixRaidenBoss2 import run_main, RaidenBossFixService, IniFile, BaseIniFile, MergedIniFile, FileService, Logger, RemapBlendModel, Error, FileException, MissingFileException, DuplicateFileException, BlendFileNotRecognized, ConflictingOptions
+from .FixRaidenBoss2 import RaidenBossFixService, IniFile, BaseIniFile, MergedIniFile, FileService, Logger, RemapBlendModel, Error, FileException, MissingFileException, DuplicateFileException, BlendFileNotRecognized, ConflictingOptions
 
 __all__ = ["RaidenBossFixService", "IniFile", "BaseIniFile", "MergedIniFile", "FileService", "Logger", "RemapBlendModel", "Error", "FileException", "MissingFileException", "DuplicateFileException", "BlendFileNotRecognized", "ConflictingOptions"]
-
-def main():
-    run_main()

--- a/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/__main__.py
+++ b/Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/__main__.py
@@ -1,4 +1,4 @@
-import FixRaidenBoss2
+from .FixRaidenBoss2 import main
 
 if __name__ == '__main__':
-    FixRaidenBoss2.main()
+    main()


### PR DESCRIPTION
Currently, the Pypi library build includes some useful classes of the script into the library, which already sets the library to be an API

Polished up some features in the script so other tool developers can now freely fix raiden mods within their own code.

### Example of Successful Run:
```python
import FixRaidenBoss2 as FRB

raidenBossFixService = FRB.RaidenBossFixService(path = r"my raiden folder path", log = True, verbose = False)
raidenBossFixService.fix()

print("The Raiden Mod is fixed!")
```

<details>
<summary>Example Result</summary>
<br>

```
Creating log file, RSFixLog.txt
The Raiden Mod is fixed!
```
</details>

### Example of Handling Errors
```python
import FixRaidenBoss2 as FRB

raidenBossFixService = FRB.RaidenBossFixService(path = r"my raiden folder path that contains a duplicate .ini file", log = True, verbose = False)

print("Starting to fix mod...")
try:
    raidenBossFixService.fix()
except FRB.DuplicateFileException as e:
    print("The fix failed because there is a duplicate .ini file... :(")
else:
    print("The Raiden Mod is fixed!")
```
<br>

<details>
<summary>Example Result</summary>
<br>

```
Starting to fix mod...
Creating log file, RSFixLog.txt
The fix failed because there is a duplicate .ini file... :(
```
</details>
<br>