### PR TITLE
Fix Merged Mods Using Only merged.ini

### DIFF
--- a/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
+++ b/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "3.2.7"
+version = "3.3.0"
 authors = [
   {name="nhok0169", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}


### PR DESCRIPTION
- merged mods do not need to go to each individual mod's `.ini file` to read in the mod's **draw value** if the draw value is given in the `merged.ini` file. So `.ini files` are now _**optional**_ for each individual mod in merged mods

- resources used in `[CommandListRaidenShogunBlend]` can have any arbitrary name instead of being named as `ResourceRaidenShogunBlend.i`

- fixed bug of file path for the resources when running the script from another folder