### PR TITLE
Add basic support for namespace merged mods

### DIFF
--- a/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
+++ b/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "3.3.1"
+version = "3.4.0"
 authors = [
   {name="nhok0169", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}


### PR DESCRIPTION
- Individual mods do not necessarily need to be referenced in the merged.ini file. Tests all first layer folders in the mod for whether the folder is an individual mod.

- The merged .ini file does not need to be named "merged.ini" if it contains `[KeySwap]` section

- .ini files of individual mods can have conditional if..else statements and other features similar to the merged.ini file