### PR TITLE
Maintain the order of variables when making fix

### DIFF
--- a/Fix-Raiden-Boss 2.0 (for all user )/README.md
+++ b/Fix-Raiden-Boss 2.0 (for all user )/README.md
@@ -8,7 +8,7 @@
 - Thank HazrateGolabi#1364 for combine and make final script
 - Thank [Albert Gold#2696](https://github.com/Alex-Au1) for update the code for merged mods
 ## Requirements 
-- [Python](https://www.python.org/downloads/)
+- [Python (version 3.6 and up)](https://www.python.org/downloads/)
 
 ## VIDEO TUTORIAL AND EXAMPLES:
 
@@ -29,9 +29,9 @@
 
 ## Let's Start !
 ### STEP 1:
-- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py) script into GIMI's `Mod` folder or your Raiden Mod folder.
+- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py) script in your Raiden Mod folder or GIMI's `Mod` folder.
 
-*Use the `--all` option to read all .ini files encountered or make sure the `.ini` files contain the section named `[TextureOverrideRaidenShogunBlend]`*
+*Make sure the `.ini` files contain the section named `[TextureOverrideRaidenShogunBlend]` or use the `--all` option to read all .ini files the program encounters*
 ### STEP 2:
 - Double click on the script
 ### STEP 3:
@@ -48,19 +48,19 @@ then enter
 *( you can now run the program anywhere without copying a script! )*
 
 ### STEP 2:
-- [open cmd](https://www.google.com/search?q=how+to+open+cmd+in+a+folder&oq=how+to+open+cmd) in your mod folder or GIMI's `Mod` folder and type:
+- [open cmd](https://www.google.com/search?q=how+to+open+cmd+in+a+folder&oq=how+to+open+cmd) in your Raiden Mod folder or GIMI's `Mod` folder and type:
 ```python
 python -m FixRaidenBoss2
 ```
 then enter
 
-*Use the `--all` option to read all .ini files encountered or make sure the `.ini` files contain the section named `[TextureOverrideRaidenShogunBlend]`*
+*Make sure the `.ini` files contain the section named `[TextureOverrideRaidenShogunBlend]` or use the `--all` option to read all .ini files the program encounters*
 ### STEP 3:
 - Open the game and enjoy it
 
 ## Run on CMD With a Script
 ### STEP 1:
-- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py) script into GIMI's `Mod` folder or your Raiden Mod folder  
+- Copy [THIS](https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)/src/FixRaidenBoss2/FixRaidenBoss2.py) script in your Raiden Mod folder or GIMI's `Mod` folder  
 
 ### STEP 2:
 - [open cmd](https://www.google.com/search?q=how+to+open+cmd+in+a+folder&oq=how+to+open+cmd) and type
@@ -69,7 +69,7 @@ python FixRaidenBoss2.py
 ```
 then enter
 
-*Use the `--all` option to read all .ini files encountered or make sure the `.ini` files contain the section named `[TextureOverrideRaidenShogunBlend]`*
+*Make sure the `.ini` files contain the section named `[TextureOverrideRaidenShogunBlend]` or use the `--all` option to read all .ini files the program encounters*
 ### STEP 3:
 - Open the game and enjoy it
 

--- a/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
+++ b/Fix-Raiden-Boss 2.0 (for all user )/pyproject.toml
@@ -4,12 +4,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "3.5.3"
+version = "3.5.4"
 authors = [
   {name="nhok0169", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}
 ]
-
 description = "A script to fix Raiden Shogun Boss Phase 1 for all types of mods"
 readme = "README.md"
 classifiers = [
@@ -17,6 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+requires-python = ">=3.6"
 
 [project.urls]
 "Homepage" = "https://github.com/nhok0169/Fix-Raiden-Boss"


### PR DESCRIPTION
The remap blend does not work if the value for `vb1` is ordered after `handling` and `draw`. 

We get this case if the modder adds the logic for their `vb1` in a subcommand

eg.
assume we have this command:

```
[CommandListRemapBlend]
if $hair == 0
   vb1 = RaidenResource1
else
   vb1 = RaidenResource2
```

<br>

**THIS BREAKS GIMI:**
```
[TextureOverrideRemapBlend]
hash = fe5c0180
handling = skip
draw = 30000,0
run = CommandListRemapBlend
```

**THIS DOES NOT BREAK GIMI:**
```
[TextureOverrideRemapBlend]
hash = fe5c0180
run = CommandListRemapBlend
handling = skip
draw = 30000,0
```

Since we use the default dictionary behavior of maintaining the order of the Key-value pairs being added  introduced in **Python 3.6**, the fix script requires user to have Python version 3.6 and up

