### PR TITLE
Fix Integration tests not checking properly

### DIFF
--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: "3.10.12"
     - name: Install Tester Dependencies
       run: python3 -m pip install -r requirements.txt
       working-directory: './Testing/Integration Tester'

--- a/.github/workflows/integration-test-workflow.yml
+++ b/.github/workflows/integration-test-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10.12"
+        python-version: ">=3.6"
     - name: Install Tester Dependencies
       run: python3 -m pip install -r requirements.txt
       working-directory: './Testing/Integration Tester'

--- a/.github/workflows/unit-test-workflow.yml
+++ b/.github/workflows/unit-test-workflow.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.x"
+        python-version: ">=3.6"
     - name: Run Unit Tests
       run: python3 main.py
       working-directory: './Testing/Unit Tester'

--- a/Testing/Integration Tester/IntegrationTester/integrationTest.py
+++ b/Testing/Integration Tester/IntegrationTester/integrationTest.py
@@ -19,6 +19,7 @@ ExpectedTestPathPrefix = "expected_"
 ResultTestPathPrefix = "output_"
 
 FolderToReplace = FRB.FileService.parseOSPath(os.path.dirname(os.path.abspath(__file__)))
+FolderToReplace = FRB.FileService.parseOSPath(os.path.dirname(FolderToReplace))
 
 class PatchService:
     def _cleanup(self, patch, target):
@@ -182,8 +183,8 @@ class IntegrationTest(unittest.TestCase, PatchService):
         exec(open(scriptPath, encoding = FileTools.FileEncoding).read(), scriptGlobals)
 
         # get the regex string to replace the folders
-        targetFolders = [targetFolder.replace(os.sep, "/"), targetFolder.replace(os.sep, "\\\\"), targetFolder.replace(os.sep, "\\\\\\\\"),
-                         FolderToReplace.replace(os.sep, "/"), FolderToReplace.replace(os.sep, "\\\\"), FolderToReplace.replace(os.sep, "\\\\\\\\")]
+        targetFolders = [targetFolder.replace(os.sep, "\\/"), targetFolder.replace(os.sep, "\\\\"), targetFolder.replace(os.sep, "\\\\\\\\"),
+                         FolderToReplace.replace(os.sep, "\\/"), FolderToReplace.replace(os.sep, "\\\\"), FolderToReplace.replace(os.sep, "\\\\\\\\")]
 
         targetFoldersReplacePattern = []
         for folder in targetFolders:

--- a/Testing/Integration Tester/IntegrationTester/integrationTest.py
+++ b/Testing/Integration Tester/IntegrationTester/integrationTest.py
@@ -169,11 +169,18 @@ class IntegrationTest(unittest.TestCase, PatchService):
         with open(file, "r", encoding = FileTools.FileEncoding) as f:
             fileTxt = f.read()
 
+        # replace absolute paths in the log file (for hiding own builds path locations)
         fileTxt = re.sub(targetFoldersReplacePattern, "absolute/path", fileTxt)
-
         with open(file, "w", encoding = FileTools.FileEncoding) as f:
             f.write(fileTxt)
-        
+
+        # create the summary text that will be compared
+        summaryFileTxt = re.split(r"\n\n#", fileTxt)[-1]
+        summaryFileTxt = re.sub(targetFoldersReplacePattern, "absolute/path", summaryFileTxt)
+
+        summaryLogFile = FRB.FileService.parseOSPath(os.path.join(os.path.dirname(file), "summaryLog.txt"))
+        with open(summaryLogFile, "w", encoding = FileTools.FileEncoding) as f:
+            f.write(summaryFileTxt)
 
     # generateOutputs(targetFolder, scriptRelPath): Executes the test script to generate outputs
     def generateOutputs(self, targetFolder: str, scriptRelPath: str):
@@ -227,6 +234,9 @@ class IntegrationTest(unittest.TestCase, PatchService):
 
             readCode = "r"
             encoding = "utf-8"
+
+            if (FileTools.isLog(path)):
+                continue
 
             # compare binary files
             if (FileTools.isBinary(path)):

--- a/Testing/Integration Tester/IntegrationTester/tools/fileTools.py
+++ b/Testing/Integration Tester/IntegrationTester/tools/fileTools.py
@@ -1,6 +1,10 @@
 import re
 import os
+import sys
 from typing import Set
+
+sys.path.insert(1, '../../Fix-Raiden-Boss 2.0 (for all user )')
+import src.FixRaidenBoss2.FixRaidenBoss2 as FRB
 
 
 # FileTools: Tools for file manipulation for the tester
@@ -11,6 +15,7 @@ class FileTools():
 
     BinaryFiles = re.compile("\.(buf)$")
     FilesToNotPrintContentPattern = re.compile("\.(buf|py)$")
+    LogFiles = re.compile("RSFixLog\.txt$")
 
     # readTestResults(): Reads the integration test results
     @classmethod
@@ -42,10 +47,15 @@ class FileTools():
     def isBinary(cls, file: str) -> bool:
         return bool(cls.BinaryFiles.search(file))
     
+    # isLog(file): Whether the file is a log file
+    @classmethod
+    def isLog(cls, file: str) -> bool:
+        return bool(cls.LogFiles.search(file))
+    
     # getFilesAndDirs(folder): Retrives all the files and folders from a folder
     @classmethod
     def getFileAndDirs(cls, folder: str, withRoot: bool = False) -> Set[str]:
-        processPath = lambda root, dirItem: dirItem
+        processPath = lambda root, dirItem: FRB.FileService.parseOSPath(os.path.relpath(FRB.FileService.parseOSPath(os.path.join(root, dirItem)), folder))
         if (withRoot):
             processPath = lambda root, dirItem: os.path.join(root, dirItem)
 

--- a/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RSFixLog.txt
+++ b/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RSFixLog.txt
@@ -74,9 +74,9 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
+# Mods/Ei/Raiden/Body/Center -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
 # Mods/Ei/Raiden/Body/Center -->     correctedBlendPath = self.blendCorrection(origFullPath, modType, fixedBlendFile = fixedFullPath)
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4120, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4120, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     with open(blendFile, "rb") as f:
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 

--- a/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RSFixLog.txt
+++ b/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RSFixLog.txt
@@ -12,78 +12,78 @@
 # Mods/Ayaka/Raiden --> Making the fixed ini file for raiden.ini
 # Mods/Ayaka/Raiden --> 
 
-# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
-# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
-# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
+# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
 # Mods/Ei/Raiden --> 
 # Mods/Ei/Raiden --> Removing any previous changes from this script in tri_merge_core.ini
 # Mods/Ei/Raiden --> 
 # Mods/Ei/Raiden --> Parsing tri_merge_core.ini...
 # Mods/Ei/Raiden --> Fixing the Blend.buf files for tri_merge_core.ini...
-# Mods/Ei/Raiden --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
-# Mods/Ei/Raiden --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
-# Mods/Ei/Raiden --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> Blend file correction done at absolute/path/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
+# Mods/Ei/Raiden --> Blend file correction done at absolute/path/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> Blend file correction done at absolute/path/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
 # Mods/Ei/Raiden --> Making the fixed ini file for tri_merge_core.ini
 # Mods/Ei/Raiden --> 
 
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
 # Mods/Ei/Raiden/leftWing --> 
 # Mods/Ei/Raiden/leftWing --> Removing any previous changes from this script in left_wing_merge.ini
 # Mods/Ei/Raiden/leftWing --> 
 # Mods/Ei/Raiden/leftWing --> Parsing left_wing_merge.ini...
 # Mods/Ei/Raiden/leftWing --> Fixing the Blend.buf files for left_wing_merge.ini...
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
 # Mods/Ei/Raiden/leftWing --> Making the fixed ini file for left_wing_merge.ini
 # Mods/Ei/Raiden/leftWing --> 
 
-# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
 # Mods/Ei/Raiden/rightWing --> 
 # Mods/Ei/Raiden/rightWing --> Removing any previous changes from this script in right_wing_merge.ini
 # Mods/Ei/Raiden/rightWing --> 
 # Mods/Ei/Raiden/rightWing --> Parsing right_wing_merge.ini...
 # Mods/Ei/Raiden/rightWing --> Fixing the Blend.buf files for right_wing_merge.ini...
-# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
 # Mods/Ei/Raiden/rightWing --> Making the fixed ini file for right_wing_merge.ini
 # Mods/Ei/Raiden/rightWing --> 
 
-# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at absolute/path/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Removing any previous changes from this script in heart.ini
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Parsing heart.ini...
 # Mods/Ei/Raiden/Body/Center --> Fixing the Blend.buf files for heart.ini...
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file correction done at absolute/path/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Mods/Ei/Raiden/Body/Center --> 
-# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: '/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
 # Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
 # Mods/Ei/Raiden/Body/Center -->     correctedBlendPath = self.blendCorrection(origFullPath, modType, fixedBlendFile = fixedFullPath)
 # Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4120, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     with open(blendFile, "rb") as f:
-# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: '/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Mods/Ei/Raiden/Body/Center --> 
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
 # Mods/Ei/Raiden/Body/Center --> Making the fixed ini file for heart.ini
 # Mods/Ei/Raiden/Body/Center --> 
 
@@ -96,7 +96,7 @@
 # Mods --> 
 # Mods --> - Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf:
 # Mods --> 	--- FileNotFoundError ---
-# Mods --> 	[Errno 2] No such file or directory: '/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods --> 	[Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods --> 
 # Mods --> ===========================================
 # Mods --> 

--- a/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/summaryLog.txt
+++ b/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/summaryLog.txt
@@ -1,0 +1,28 @@
+ Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> WARNING: The following Blend.buf files were skipped due to warnings (see log above):
+# Mods --> 
+# Mods --> ===== Mod: Mods/Ei/Raiden/Body/Center =====
+# Mods --> 
+# Mods --> - Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf:
+# Mods --> 	--- FileNotFoundError ---
+# Mods --> 	[Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods --> 
+# Mods --> ===========================================
+# Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> 
+# Mods --> 
+# Mods --> ========== Summary ==========
+# Mods --> 
+# Mods --> - Out of 5 found mods, fixed 5 mods and skipped 0 mods
+# Mods --> - Out of the 5 *.ini files within the found mods, fixed 5 *.ini files and skipped 0 *.ini file files
+# Mods --> - Out of the 11 Blend.buf files within the found mods, fixed 10 Blend.buf files and skipped 1 Blend.buf files
+# Mods --> 
+# Mods --> =============================
+# Mods --> 
+
+
+Creating log file, RSFixLog.txt

--- a/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Logs/RSFixLog.txt
+++ b/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Logs/RSFixLog.txt
@@ -26,55 +26,55 @@
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Mods/Arlecchino --> 
-# Mods/Arlecchino --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Arlecchino1/RemapBlend.buf
-# Mods/Arlecchino --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Arlecchino2/RemapBlend.buf
+# Mods/Arlecchino --> No Previous RemapBlend.buf found at absolute/path/Mods/Arlecchino/Arlecchino1/RemapBlend.buf
+# Mods/Arlecchino --> No Previous RemapBlend.buf found at absolute/path/Mods/Arlecchino/Arlecchino2/RemapBlend.buf
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> the ini file, bad_merged.ini, has alreaedy encountered an error
 # Mods/Arlecchino --> Parsing good_merged.ini...
 # Mods/Arlecchino --> Fixing the Blend.buf files for good_merged.ini...
-# Mods/Arlecchino --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Arlecchino1/RemapBlend.buf
-# Mods/Arlecchino --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Arlecchino2/RemapBlend.buf
+# Mods/Arlecchino --> Blend file correction done at absolute/path/Mods/Arlecchino/Arlecchino1/RemapBlend.buf
+# Mods/Arlecchino --> Blend file correction done at absolute/path/Mods/Arlecchino/Arlecchino2/RemapBlend.buf
 # Mods/Arlecchino --> Making the fixed ini file for good_merged.ini
 # Mods/Arlecchino --> 
 
-# Mods/Ayaka --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ayaka/ayakaRemapBlend.buf
+# Mods/Ayaka --> No Previous RemapBlend.buf found at absolute/path/Mods/Ayaka/ayakaRemapBlend.buf
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Parsing ayaka.ini...
 # Mods/Ayaka --> Fixing the Blend.buf files for ayaka.ini...
 # Mods/Ayaka --> 
 # Mods/Ayaka --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Mods/Ayaka --> 
-# Mods/Ayaka --> BlendFileNotRecognized: ERROR: Blend file format not recognized for ayakaBlend.buf at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ayaka
+# Mods/Ayaka --> BlendFileNotRecognized: ERROR: Blend file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
 # Mods/Ayaka -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
 # Mods/Ayaka -->     correctedBlendPath = self.blendCorrection(origFullPath, modType, fixedBlendFile = fixedFullPath)
 # Mods/Ayaka -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4127, in blendCorrection
 # Mods/Ayaka -->     raise BlendFileNotRecognized(blendFile)
-# Mods/Ayaka --> src.FixRaidenBoss2.FixRaidenBoss2.BlendFileNotRecognized: ERROR: Blend file format not recognized for ayakaBlend.buf at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ayaka
+# Mods/Ayaka --> src.FixRaidenBoss2.FixRaidenBoss2.BlendFileNotRecognized: ERROR: Blend file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Making the fixed ini file for ayaka.ini
 # Mods/Ayaka --> 
 
-# Mods/Griffith --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/OneWingedAngel/EvilRemapBlend.buf
+# Mods/Griffith --> No Previous RemapBlend.buf found at absolute/path/OneWingedAngel/EvilRemapBlend.buf
 # Mods/Griffith --> 
 # Mods/Griffith --> Parsing griffith.ini...
 # Mods/Griffith --> Fixing the Blend.buf files for griffith.ini...
-# Mods/Griffith --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/OneWingedAngel/EvilRemapBlend.buf
+# Mods/Griffith --> Blend file correction done at absolute/path/OneWingedAngel/EvilRemapBlend.buf
 # Mods/Griffith --> Making the fixed ini file for griffith.ini
 # Mods/Griffith --> 
 
 # Mods/Arlecchino/Arlecchino1 --> Parsing DISABLED_arlecchino.ini...
 # Mods/Arlecchino/Arlecchino1 --> Fixing the Blend.buf files for DISABLED_arlecchino.ini...
-# Mods/Arlecchino/Arlecchino1 --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Arlecchino1/RemapBlend.buf
+# Mods/Arlecchino/Arlecchino1 --> Blend file has already been corrected at absolute/path/Mods/Arlecchino/Arlecchino1/RemapBlend.buf
 # Mods/Arlecchino/Arlecchino1 --> Making the fixed ini file for DISABLED_arlecchino.ini
 # Mods/Arlecchino/Arlecchino1 --> 
 
 # Mods/Arlecchino/Arlecchino2 --> Parsing DISABLED_arlecchino.ini...
 # Mods/Arlecchino/Arlecchino2 --> Fixing the Blend.buf files for DISABLED_arlecchino.ini...
-# Mods/Arlecchino/Arlecchino2 --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Arlecchino2/RemapBlend.buf
+# Mods/Arlecchino/Arlecchino2 --> Blend file has already been corrected at absolute/path/Mods/Arlecchino/Arlecchino2/RemapBlend.buf
 # Mods/Arlecchino/Arlecchino2 --> Making the fixed ini file for DISABLED_arlecchino.ini
 # Mods/Arlecchino/Arlecchino2 --> 
 
@@ -108,11 +108,11 @@
 # Mods/Arlecchino/Ugly --> the ini file, shawshank redemption.ini, has alreaedy encountered an error
 # Mods/Arlecchino/Ugly --> 
 
-# Mods/Ayaka/Arlecchino --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ayaka/Arlecchino/arlecchinoRemapBlend.buf
+# Mods/Ayaka/Arlecchino --> No Previous RemapBlend.buf found at absolute/path/Mods/Ayaka/Arlecchino/arlecchinoRemapBlend.buf
 # Mods/Ayaka/Arlecchino --> 
 # Mods/Ayaka/Arlecchino --> Parsing arlecchino.ini...
 # Mods/Ayaka/Arlecchino --> Fixing the Blend.buf files for arlecchino.ini...
-# Mods/Ayaka/Arlecchino --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ayaka/Arlecchino/arlecchinoRemapBlend.buf
+# Mods/Ayaka/Arlecchino --> Blend file correction done at absolute/path/Mods/Ayaka/Arlecchino/arlecchinoRemapBlend.buf
 # Mods/Ayaka/Arlecchino --> Making the fixed ini file for arlecchino.ini
 # Mods/Ayaka/Arlecchino --> 
 
@@ -123,84 +123,84 @@
 # Mods/Ayaka/Raiden --> Making the fixed ini file for raiden.ini
 # Mods/Ayaka/Raiden --> 
 
-# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
-# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
-# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
+# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
 # Mods/Ei/Raiden --> 
 # Mods/Ei/Raiden --> Removing any previous changes from this script in tri_merge_core.ini
 # Mods/Ei/Raiden --> 
 # Mods/Ei/Raiden --> Parsing tri_merge_core.ini...
 # Mods/Ei/Raiden --> Fixing the Blend.buf files for tri_merge_core.ini...
-# Mods/Ei/Raiden --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
-# Mods/Ei/Raiden --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
-# Mods/Ei/Raiden --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> Blend file correction done at absolute/path/Mods/Ei/Raiden/Body/BodyEntityRemapBlend.buf
+# Mods/Ei/Raiden --> Blend file correction done at absolute/path/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden --> Blend file correction done at absolute/path/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
 # Mods/Ei/Raiden --> Making the fixed ini file for tri_merge_core.ini
 # Mods/Ei/Raiden --> 
 
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
 # Mods/Ei/Raiden/leftWing --> 
 # Mods/Ei/Raiden/leftWing --> Removing any previous changes from this script in left_wing_merge.ini
 # Mods/Ei/Raiden/leftWing --> 
 # Mods/Ei/Raiden/leftWing --> Parsing left_wing_merge.ini...
 # Mods/Ei/Raiden/leftWing --> Fixing the Blend.buf files for left_wing_merge.ini...
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
-# Mods/Ei/Raiden/leftWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/leftWing/LeftWingEntityRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/leftWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
 # Mods/Ei/Raiden/leftWing --> Making the fixed ini file for left_wing_merge.ini
 # Mods/Ei/Raiden/leftWing --> 
 
-# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
 # Mods/Ei/Raiden/rightWing --> 
 # Mods/Ei/Raiden/rightWing --> Removing any previous changes from this script in right_wing_merge.ini
 # Mods/Ei/Raiden/rightWing --> 
 # Mods/Ei/Raiden/rightWing --> Parsing right_wing_merge.ini...
 # Mods/Ei/Raiden/rightWing --> Fixing the Blend.buf files for right_wing_merge.ini...
-# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
-# Mods/Ei/Raiden/rightWing --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/Body/listeners/heartListenerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/rightWing/RightWingEntityRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file correction done at absolute/path/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/rightWing --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/Body/controllers/heartPumpControllerRemapBlend.buf
 # Mods/Ei/Raiden/rightWing --> Making the fixed ini file for right_wing_merge.ini
 # Mods/Ei/Raiden/rightWing --> 
 
-# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at absolute/path/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> No Previous RemapBlend.buf found at absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Removing any previous changes from this script in heart.ini
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Parsing heart.ini...
 # Mods/Ei/Raiden/Body/Center --> Fixing the Blend.buf files for heart.ini...
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file correction done at absolute/path/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Mods/Ei/Raiden/Body/Center --> 
-# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: '/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
 # Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
 # Mods/Ei/Raiden/Body/Center -->     correctedBlendPath = self.blendCorrection(origFullPath, modType, fixedBlendFile = fixedFullPath)
 # Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4120, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     with open(blendFile, "rb") as f:
-# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: '/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # Mods/Ei/Raiden/Body/Center --> 
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/rightWing/listeners/rightWingListenerRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/leftWing/listeners/leftWingListenerRemapBlend.buf
-# Mods/Ei/Raiden/Body/Center --> Blend file correction done at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Makoto/MakotoRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/rightWing/controllers/rightWingControllerRemapBlend.buf
+# Mods/Ei/Raiden/Body/Center --> Blend file has already been corrected at absolute/path/Mods/Ei/Raiden/leftWing/controllers/leftWingControllerRemapBlend.buf
 # Mods/Ei/Raiden/Body/Center --> Making the fixed ini file for heart.ini
 # Mods/Ei/Raiden/Body/Center --> 
 
 # OneWingedAngel --> Parsing oneWingedAngel.ini...
 # OneWingedAngel --> Fixing the Blend.buf files for oneWingedAngel.ini...
-# OneWingedAngel --> Blend file has already been corrected at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/OneWingedAngel/EvilRemapBlend.buf
+# OneWingedAngel --> Blend file has already been corrected at absolute/path/OneWingedAngel/EvilRemapBlend.buf
 # OneWingedAngel --> Making the fixed ini file for oneWingedAngel.ini
 # OneWingedAngel --> 
 
@@ -209,7 +209,7 @@
 # Mods --> 
 # Mods --> WARNING: The following mods were skipped due to warnings (see log above):
 # Mods --> 
-# Mods --> - /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Ugly:
+# Mods --> - absolute/path/Mods/Arlecchino/Ugly:
 # Mods --> 	--- KeyError ---
 # Mods --> 	"The section by the name 'BadCommand' does not exist"
 # Mods --> 
@@ -222,11 +222,11 @@
 # Mods --> 
 # Mods --> WARNING: The following *.ini files were skipped due to warnings (see log above):
 # Mods --> 
-# Mods --> - /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/bad_merged.ini:
+# Mods --> - absolute/path/Mods/Arlecchino/bad_merged.ini:
 # Mods --> 	--- KeyError ---
 # Mods --> 	"The resource by the name, 'glitchedOutResource', does not exist"
 # Mods --> 
-# Mods --> - /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Arlecchino/Ugly/shawshank redemption.ini:
+# Mods --> - absolute/path/Mods/Arlecchino/Ugly/shawshank redemption.ini:
 # Mods --> 	--- KeyError ---
 # Mods --> 	"The section by the name 'BadCommand' does not exist"
 # Mods --> 
@@ -243,14 +243,14 @@
 # Mods --> 
 # Mods --> - Ayaka/ayakaRemapBlend.buf:
 # Mods --> 	--- BlendFileNotRecognized ---
-# Mods --> 	ERROR: Blend file format not recognized for ayakaBlend.buf at /mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ayaka
+# Mods --> 	ERROR: Blend file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods --> 
 # Mods --> ===========================
 # Mods --> ===== Mod: Mods/Ei/Raiden/Body/Center =====
 # Mods --> 
 # Mods --> - Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf:
 # Mods --> 	--- FileNotFoundError ---
-# Mods --> 	[Errno 2] No such file or directory: '/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods --> 	[Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods --> 
 # Mods --> ===========================================
 # Mods --> 

--- a/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Logs/RSFixLog.txt
+++ b/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Logs/RSFixLog.txt
@@ -11,16 +11,16 @@
 # Mods/Arlecchino --> KeyError: "The resource by the name, 'glitchedOutResource', does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3659, in parse
+# Mods/Arlecchino -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3659, in parse
 # Mods/Arlecchino -->     self._resourceBlends[blend] = self._sectionIfTemplates[blend]
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4020, in removeFix
+# Mods/Arlecchino -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4020, in removeFix
 # Mods/Arlecchino -->     ini.parse()
-# Mods/Arlecchino -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3661, in parse
+# Mods/Arlecchino -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3661, in parse
 # Mods/Arlecchino -->     raise KeyError(f"The resource by the name, '{blend}', does not exist") from e
 # Mods/Arlecchino --> KeyError: "The resource by the name, 'glitchedOutResource', does not exist"
 # Mods/Arlecchino --> 
@@ -47,9 +47,9 @@
 # Mods/Ayaka --> BlendFileNotRecognized: ERROR: Blend file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
+# Mods/Ayaka -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
 # Mods/Ayaka -->     correctedBlendPath = self.blendCorrection(origFullPath, modType, fixedBlendFile = fixedFullPath)
-# Mods/Ayaka -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4127, in blendCorrection
+# Mods/Ayaka -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4127, in blendCorrection
 # Mods/Ayaka -->     raise BlendFileNotRecognized(blendFile)
 # Mods/Ayaka --> src.FixRaidenBoss2.FixRaidenBoss2.BlendFileNotRecognized: ERROR: Blend file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -84,22 +84,22 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'BadCommand' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3529, in _getCommandIfTemplate
+# Mods/Arlecchino/Ugly -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3529, in _getCommandIfTemplate
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._sectionIfTemplates[sectionName]
 # Mods/Arlecchino/Ugly --> KeyError: 'BadCommand'
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4020, in removeFix
+# Mods/Arlecchino/Ugly -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4020, in removeFix
 # Mods/Arlecchino/Ugly -->     ini.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3654, in parse
+# Mods/Arlecchino/Ugly -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3654, in parse
 # Mods/Arlecchino/Ugly -->     self._getBlendResources(self._textureOverrideBlendRoot, blendResources, subCommands, subCommandLst)
-# Mods/Arlecchino/Ugly -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3579, in _getBlendResources
+# Mods/Arlecchino/Ugly -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3579, in _getBlendResources
 # Mods/Arlecchino/Ugly -->     self._getBlendResources(sectionName, blendResources, subCommands, subCommandLst)
-# Mods/Arlecchino/Ugly -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3563, in _getBlendResources
+# Mods/Arlecchino/Ugly -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3563, in _getBlendResources
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._getCommandIfTemplate(sectionName)
-# Mods/Arlecchino/Ugly -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3532, in _getCommandIfTemplate
+# Mods/Arlecchino/Ugly -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 3532, in _getCommandIfTemplate
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'BadCommand' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -185,9 +185,9 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
+# Mods/Ei/Raiden/Body/Center -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4241, in correctBlend
 # Mods/Ei/Raiden/Body/Center -->     correctedBlendPath = self.blendCorrection(origFullPath, modType, fixedBlendFile = fixedFullPath)
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/d/Computer/Games/Genshin/Repos/Repos/Fix-Raiden-Boss-Fork/Testing/Integration Tester/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4120, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "absolute/path/../../Fix-Raiden-Boss 2.0 (for all user )/src/FixRaidenBoss2/FixRaidenBoss2.py", line 4120, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     with open(blendFile, "rb") as f:
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 

--- a/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Logs/summaryLog.txt
+++ b/Testing/Integration Tester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsWithoutBackups/Logs/summaryLog.txt
@@ -1,0 +1,65 @@
+ Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> WARNING: The following mods were skipped due to warnings (see log above):
+# Mods --> 
+# Mods --> - absolute/path/Mods/Arlecchino/Ugly:
+# Mods --> 	--- KeyError ---
+# Mods --> 	"The section by the name 'BadCommand' does not exist"
+# Mods --> 
+# Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> 
+# Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> WARNING: The following *.ini files were skipped due to warnings (see log above):
+# Mods --> 
+# Mods --> - absolute/path/Mods/Arlecchino/bad_merged.ini:
+# Mods --> 	--- KeyError ---
+# Mods --> 	"The resource by the name, 'glitchedOutResource', does not exist"
+# Mods --> 
+# Mods --> - absolute/path/Mods/Arlecchino/Ugly/shawshank redemption.ini:
+# Mods --> 	--- KeyError ---
+# Mods --> 	"The section by the name 'BadCommand' does not exist"
+# Mods --> 
+# Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> 
+# Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> WARNING: The following Blend.buf files were skipped due to warnings (see log above):
+# Mods --> 
+# Mods --> ===== Mod: Mods/Ayaka =====
+# Mods --> 
+# Mods --> - Ayaka/ayakaRemapBlend.buf:
+# Mods --> 	--- BlendFileNotRecognized ---
+# Mods --> 	ERROR: Blend file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
+# Mods --> 
+# Mods --> ===========================
+# Mods --> ===== Mod: Mods/Ei/Raiden/Body/Center =====
+# Mods --> 
+# Mods --> - Ei/Raiden/Body/whoopsIReferencedTheWrongThingRemapBlend.buf:
+# Mods --> 	--- FileNotFoundError ---
+# Mods --> 	[Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
+# Mods --> 
+# Mods --> ===========================================
+# Mods --> 
+# Mods --> !!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+# Mods --> 
+# Mods --> 
+# Mods --> 
+# Mods --> ========== Summary ==========
+# Mods --> 
+# Mods --> - Out of 13 found mods, fixed 12 mods and skipped 1 mods
+# Mods --> - Out of the 14 *.ini files within the found mods, fixed 12 *.ini files and skipped 2 *.ini file files
+# Mods --> - Out of the 16 Blend.buf files within the found mods, fixed 14 Blend.buf files and skipped 2 Blend.buf files
+# Mods --> 
+# Mods --> =============================
+# Mods --> 
+
+
+Creating log file, RSFixLog.txt

--- a/Testing/Integration Tester/Tests/MixedModsTests/mixedModTests.py
+++ b/Testing/Integration Tester/Tests/MixedModsTests/mixedModTests.py
@@ -1,4 +1,5 @@
 from IntegrationTester import IntegrationTest
+from ordered_set import OrderedSet
 import os
 
 
@@ -7,6 +8,9 @@ class MixedModsTest(IntegrationTest):
     def getTestPath(self) -> str:
         return os.path.dirname(os.path.abspath(__file__))
     
+    def setUp(self):
+        self.patch("builtins.set", OrderedSet)
+
 
     def test_fullFixNotBackups_fixModsWithoutBackups(self):
         self.runTest("fullFixNoBackups_fixModsWithoutBackups", r"Mods\fullFixNoBackups_fixModsWithoutBackups.py")

--- a/Testing/Integration Tester/Tests/MixedModsTests/mixedModTests.py
+++ b/Testing/Integration Tester/Tests/MixedModsTests/mixedModTests.py
@@ -1,5 +1,6 @@
 from IntegrationTester import IntegrationTest
 from ordered_set import OrderedSet
+from collections import OrderedDict
 import os
 
 
@@ -10,6 +11,7 @@ class MixedModsTest(IntegrationTest):
     
     def setUp(self):
         self.patch("builtins.set", OrderedSet)
+        self.patch("builtins.dict", OrderedDict)
 
 
     def test_fullFixNotBackups_fixModsWithoutBackups(self):

--- a/Testing/Integration Tester/requirements.txt
+++ b/Testing/Integration Tester/requirements.txt
@@ -1,1 +1,2 @@
 directory-tree==0.0.4
+ordered-set==4.1.0


### PR DESCRIPTION
- Allow integration tests to check all files
- Only check the summary part of the log since the order of operations for the front part of the log is very dependent on how the machine handles system calls
- Mock uses of `set` with `ordered-set` and `dict` and `OrderedDict` to maintain order for those data structures