### PR TITLE
Link the README of the repo to the README of Fix-Raiden-Boss2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # FIX RAIDEN BOSS
-<a href=""><img alt="" src="https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/docs/src/_static/images/raiden.jpg" style="width:750px; height: auto;"></a>
-- make be [NK#1321](https://discordapp.com/users/277117247523389450)
+[![PyPI](https://img.shields.io/pypi/pyversions/FixRaidenBoss2)](https://www.python.org/downloads/)
+[![PyPI](https://img.shields.io/pypi/v/FixRaidenBoss2)](https://pypi.org/project/FixRaidenBoss2/)
+[![PyPI](https://img.shields.io/pypi/dm/FixRaidenBoss2?label=pypi%20downloads)](https://pypi.org/project/FixRaidenBoss2/)
+[![Documentation Status](https://readthedocs.org/projects/fix-raiden-boss/badge/?version=latest)](https://fix-raiden-boss.readthedocs.io/en/latest/?badge=latest)
+
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/nhok0169/Fix-Raiden-Boss/unit-tests.yml?label=Unit%20Tests)](https://github.com/nhok0169/Fix-Raiden-Boss/actions/workflows/unit-tests.yml)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/nhok0169/Fix-Raiden-Boss/integration-tests.yml?label=Integration%20Tests)](https://github.com/nhok0169/Fix-Raiden-Boss/actions/workflows/integration-tests.yml)
+
+
+<a href=""><img alt="" src="https://github.com/nhok0169/Fix-Raiden-Boss/blob/nhok0169/Docs/src/_static/images/raiden.jpg" style="width:750px; height: auto;"></a>
+
+## Contributors
+- Original Author: [NK#1321](https://discordapp.com/users/277117247523389450)
+- [Albert Gold#2696](https://github.com/Alex-Au1)
+
+
+## How To Run:
+Go to [this link](https://github.com/nhok0169/Fix-Raiden-Boss/tree/nhok0169/Fix-Raiden-Boss%202.0%20(for%20all%20user%20)) for more info.


### PR DESCRIPTION
- People are complaining about being hard to use when there is already a detailed README [here](https://github.com/nhok0169/Fix-Raiden-Boss/tree/nhok0169). They are probably don't know that they need to click on that folder to see the README