### PR TITLE
Upgrade to V4 Artifact Actions

### DIFF
--- a/.github/workflows/mirror-publish.yml
+++ b/.github/workflows/mirror-publish.yml
@@ -42,7 +42,7 @@ jobs:
       run: python3 -m build
       working-directory: './Anime Game Remap (for all users)/apiMirror'
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: 'Anime Game Remap (for all users)/apiMirror/dist/'
@@ -61,7 +61,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,7 +44,7 @@ jobs:
       run: python3 -m build
       working-directory: './Anime Game Remap (for all users)/api'
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: 'Anime Game Remap (for all users)/api/dist/'
@@ -63,7 +63,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/

--- a/.github/workflows/utility-publish.yml
+++ b/.github/workflows/utility-publish.yml
@@ -37,7 +37,7 @@ jobs:
       run: python3 -m build
       working-directory: './Tools/Utilities'
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: 'Tools/Utilities/dist/'
@@ -56,7 +56,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
- V3 is deprecated and will fail in Github actions 
https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/