### PR TITLE
Fix IB handling in HuTao Remap

### DIFF
--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
@@ -214,6 +214,27 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def hutao5_6(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head"], "body": ["body", "body"], "dress": ["body", "body"], "extra": ["head", "head"]}],
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"},
+                                        "body": {"ps-t2", "ps-t3"}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"extra": {"ps-t0", "ps-t1"}}),
+                    RegNewVals(vals = {"extra": {IniKeywords.Ib.value: "null"}, 
+                                       "dress": {IniKeywords.Ib.value: "null"}}),
+                    RegTexEdit(textures = {"TransparentHeadDiffuse": ["ps-t0"]}),
+                    RegRemap(remap = {"head": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2"]},
+                                        "dress": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2"]}}),
+                    RegNewVals(vals = {"head": {"ps-t0": "null"}}),
+                    RegTexAdd(textures = {"dress": {"ps-t0": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapBlue.value))}}, mustAdd = False)
+                ],
+                "iniPostModelRegEditFilters": [[RegNewVals(vals = {IniKeywords.Ib.value: {"hash": "null"}})], []]})
+    
+    @classmethod
     def jean4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (MultiModFixer, 
                 [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer), 
@@ -604,6 +625,9 @@ IniFixBuilderData = {
     5.5: {
         ModTypeNames.Jean.value: IniFixBuilderFuncs.jean5_5,
         ModTypeNames.JeanCN.value: IniFixBuilderFuncs.jeanCN5_5
+    },
+    5.6: {
+        ModTypeNames.HuTao.value: IniFixBuilderFuncs.hutao5_6
     }
 }
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIFixer.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIFixer.py
@@ -12,7 +12,8 @@
 ##### EndCredits
 
 ##### ExtImports
-from typing import Callable, Optional, Set, Dict
+import copy
+from typing import Callable, Optional, Set, Dict, List
 ##### EndExtImports
 
 ##### LocalImports
@@ -23,6 +24,7 @@ from ....tools.Heading import Heading
 from ...iftemplate.IfContentPart import IfContentPart
 from ...iftemplate.IfTemplate import IfTemplate
 from ...IniSectionGraph import IniSectionGraph
+from .regEditFilters.RegEditFilter import RegEditFilter
 ##### EndLocalImports
 
 
@@ -37,10 +39,23 @@ class GIMIFixer(BaseIniFixer):
     ----------
     parser: :class:`GIMIParser`
         The associated parser to retrieve data for the fix
+
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
+    Attributes
+    ----------
+    postModelRegEditFilters: List[:class:`RegEditFilter`]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list.
     """
 
-    def __init__(self, parser: GIMIParser):
+    def __init__(self, parser: GIMIParser, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
         super().__init__(parser)
+        self.postModelRegEditFilters = [] if (postModelRegEditFilters is None) else postModelRegEditFilters
 
     def clear(self):
         super().clear()
@@ -52,6 +67,39 @@ class GIMIFixer(BaseIniFixer):
         if (modName in modsToFix):
             return self._getRemapName(sectionName, modName, sectionGraph = sectionGraph, remapNameFunc = remapNameFunc)
         return sectionName
+    
+    def editModelRegisters(self, modName: str, part: IfContentPart, modelPartName: str, sectionName: str, filters: List[RegEditFilter]):
+        """
+        Edits the registers for a :class:`IfContentPart` in the .VB or .IB `sections`_
+
+        .. note::
+            For details on steps of how the registers are editted, see :class:`GIMIObjReplaceFixer`
+
+        Parameters
+        ----------
+        modName: :class:`str`
+            The name of the mod to fix to
+
+        part: :class:`IfContentPart`
+            The part that is being editted
+
+        modelPartName: :class:`str`
+            The name of the part within the .VB or .IB `sections`_
+
+        sectionName: :class:`str`
+            The name of the `section`_ the part belongs to
+
+        filters: List[:class:`BaseRegEditFilter`]
+            The filters used for editting the registers
+        """
+
+        modType = self._iniFile.availableType
+        if (modType is None):
+            return
+        
+        for filter in filters:
+            filter.clear()
+            filter._editReg(part, modType, modName, modelPartName, sectionName, self)
 
     def _fillTextureOverrideRemapBlend(self, modName: str, sectionName: str, part: IfContentPart, partIndex: int, linePrefix: str, origSectionName: str) -> str:
         """
@@ -87,43 +135,39 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.blendCommandsGraph)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the vb1 resource
             elif (varName == IniKeywords.Vb1.value):
                 blendName = varValue
                 remapBlendName = self._getRemapName(blendName, modName, sectionGraph = self._parser.blendResourceCommandsGraph, remapNameFunc = self._iniFile.getRemapBlendResourceName)
-                fixStr = f'{IniKeywords.Vb1.value} = {remapBlendName}'
-                addFix += f"{linePrefix}{fixStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{remapBlendName}")
 
             # filling in the handling
             elif (varName == IniKeywords.Handling.value):
-                fixStr = f'{IniKeywords.Handling.value} = skip'
-                addFix += f"{linePrefix}{fixStr}\n"
-
-            # filling in the draw value
-            elif (varName == IniKeywords.Draw.value):
-                fixStr = f'{IniKeywords.Draw.value} = {varValue}'
-                addFix += f"{linePrefix}{fixStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"skip")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"index")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Blend.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     
@@ -161,33 +205,35 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.positionCommandsGraph, remapNameFunc = self._iniFile.getRemapPositionName)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the vb0 resource
             elif (varName == IniKeywords.Vb0.value):
                 positionName = varValue
                 remapPositionName = self._getBufRemapName(positionName, modName, self._parser._positionEditModsToFix, sectionGraph = self._parser.positionResourceCommandsGraph, remapNameFunc = self._iniFile.getRemapPositionResourceName)
-                fixStr = f'{IniKeywords.Vb0.value} = {remapPositionName}'
-                addFix += f"{linePrefix}{fixStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{remapPositionName}")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{index}")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Position.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     
@@ -225,26 +271,29 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.texcoordCommandsGraph, remapNameFunc = self._iniFile.getRemapTexcoordName)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{index}")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Texcoord.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     
@@ -282,26 +331,29 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.ibCommandsGraph, remapNameFunc = self._iniFile.getRemapIbName)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{index}")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Ib.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjMergeFixer.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjMergeFixer.py
@@ -13,7 +13,7 @@
 
 ##### ExtImports
 import copy
-from typing import Dict, List, Union, Set, Optional
+from typing import Dict, List, Union, Set, Optional, Tuple
 ##### EndExtImports
 
 ##### LocalImports
@@ -22,6 +22,7 @@ from ....tools.DictTools import DictTools
 from .GIMIObjReplaceFixer import GIMIObjReplaceFixer
 from ..iniParsers.GIMIObjParser import GIMIObjParser
 from .regEditFilters.BaseRegEditFilter import BaseRegEditFilter
+from .regEditFilters.RegEditFilter import RegEditFilter
 ##### EndLocalImports
 
 
@@ -86,6 +87,11 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
 
         **Default**: ``None``
 
+    iniPostModelRegEditFilters: Optional[List[List[:class:`RegEditFilter`]]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod for each .ini file :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
     Attributes
     ----------
     _targetObjs: Dict[:class:`str`, :class:`str`]
@@ -95,12 +101,22 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
 
     copyPreamble: :class:`str`
         Any text we want to put before the text of the newly generated .ini file variations
+
+    iniPostModelRegEditFilters: List[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod for each .ini file
+
+    postModelRegEditFilters: List[:class:`RegEditFilter`]
+        The filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod for the current .ini file being generated
     """
 
     def __init__(self, parser: GIMIObjParser, objs: Dict[str, List[str]], copyPreamble: str = "", 
-                 preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None):
+                 preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None,
+                 iniPostModelRegEditFilters: Optional[List[List[RegEditFilter]]] = None):
+
+        self.iniPostModelRegEditFilters = [] if (iniPostModelRegEditFilters is None) else iniPostModelRegEditFilters
+
         super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters)
-        self._targetObjs: Dict[str, str] = {}
+        self._targetObjs: List[Tuple[str, str]]
         self._maxObjsToMergeLen = 0
         self._sectionsToIgnore: Set[str] = set()
         self.objs = objs
@@ -147,8 +163,7 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
             fix += "\n"
 
         # retrieve the fix for all the merged mod objects
-        for objToFix in self._targetObjs:
-            fixedObj = self._targetObjs[objToFix]
+        for objToFix, fixedObj in self._targetObjs:
             objGraph = self._parser.objGraphs[objToFix]
 
             if (not objGraph.sections):
@@ -171,12 +186,20 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
     
     # _getCurrentTargetObjs(ind): Retrieves the current mod objects to show in the current .ini file for each merged mod object
     def _getCurrentTargetObjs(self, ind: int):
-        self._targetObjs = {}
+        self._targetObjs = []
         for mergedObj in self._objs:
             objsToMerge = self._objs[mergedObj]
             if (ind <= len(objsToMerge) - 1):
                 objToMerge = objsToMerge[ind]
-                self._targetObjs[objToMerge] = mergedObj
+                self._targetObjs.append((objToMerge, mergedObj))
+
+    # _getCurrentModelRegEditFilters(ind): Retrieves the current register editting filters to edit the sections to the .ib/.vb of the mod
+    def _getCurrentModelRegEditFilters(self, ind: int):
+        if (len(self.iniPostModelRegEditFilters) <= ind):
+            self.postModelRegEditFilters = []
+            return
+        
+        self.postModelRegEditFilters = self.iniPostModelRegEditFilters[ind]
 
     # _getIgnoredSections(): Retrieves which sections to ignore when performing the normal part of the fix
     def _getIgnoredSections(self):
@@ -212,6 +235,8 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
         texEditModels = {}
         for i in range(self._maxObjsToMergeLen):
             self._getCurrentTargetObjs(i)
+            self._getCurrentModelRegEditFilters(i)
+
             if (i > 0 and iniFilePath is not None):
                 iniFilePath.baseName = f"{iniBaseName}{FileSuffixes.RemapFixCopy.value}{i}"
 

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjRegEditFixer.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjRegEditFixer.py
@@ -12,6 +12,7 @@
 ##### EndCredits
 
 ##### ExtImports
+import copy
 from typing import Optional, List
 ##### EndExtImports
 
@@ -19,6 +20,7 @@ from typing import Optional, List
 from .GIMIObjSplitFixer import GIMIObjSplitFixer
 from ..iniParsers.GIMIObjParser import GIMIObjParser
 from .regEditFilters.BaseRegEditFilter import BaseRegEditFilter
+from .regEditFilters.RegEditFilter import RegEditFilter
 ##### EndLocalImports
 
 
@@ -57,11 +59,17 @@ class GIMIObjRegEditFixer(GIMIObjSplitFixer):
         :raw-html:`<br />`
 
         **Default**: ``None``
+
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
     """
 
     def __init__(self, parser: GIMIObjParser, preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, 
-                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None):
-        super().__init__(parser, {}, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters)
+                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
+        super().__init__(parser, {}, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, postModelRegEditFilters = postModelRegEditFilters)
 
         parserObjs = sorted(self._parser.objs)
         for obj in parserObjs:

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjReplaceFixer.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjReplaceFixer.py
@@ -30,6 +30,7 @@ from ..iniParsers.GIMIObjParser import GIMIObjParser
 from ...iftemplate.IfContentPart import IfContentPart
 from ...iftemplate.IfTemplate import IfTemplate
 from .regEditFilters.BaseRegEditFilter import BaseRegEditFilter
+from .regEditFilters.RegEditFilter import RegEditFilter
 from .regEditFilters.RegTexAdd import RegTexAdd
 from ..texEditors.TexCreator import TexCreator
 from ...IniSectionGraph import IniSectionGraph
@@ -74,6 +75,12 @@ class GIMIObjReplaceFixer(GIMIFixer):
 
         **Default**: ``True``
 
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
     Attributes
     ----------
     preRegEditOldObj: :class:`bool`
@@ -95,8 +102,8 @@ class GIMIObjReplaceFixer(GIMIFixer):
     """
 
     def __init__(self, parser: GIMIObjParser, preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None,
-                 preRegEditOldObj: bool = True):
-        super().__init__(parser)
+                 preRegEditOldObj: bool = True, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
+        super().__init__(parser, postModelRegEditFilters = postModelRegEditFilters)
         self._texInds: Dict[str, Dict[str, int]] = {}
         self._texEditRemapNames: Dict[str, Dict[str, str]] = {}
         self._texAddRemapNames: Dict[str, Dict[str, str]] = {}
@@ -261,9 +268,9 @@ class GIMIObjReplaceFixer(GIMIFixer):
     def getObjHashType(self):
         return "ib"
     
-    def editRegisters(self, modName: str, part: IfContentPart, obj: str, sectionName: str, filters: List[BaseRegEditFilter]):
+    def editTexRegisters(self, modName: str, part: IfContentPart, obj: str, sectionName: str, filters: List[BaseRegEditFilter]):
         """
-        Edits the registers for a :class:`IfContentPart`
+        Edits the registers for a :class:`IfContentPart` in the texture related `section`_
 
         .. note::
             For details on steps of how the registers are editted, see :class:`GIMIObjReplaceFixer`
@@ -271,7 +278,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
         Parameters
         ----------
         modName: :class:`str`
-            The name of the mod
+            The name of the mod to fix to
 
         part: :class:`IfContentPart`
             The part that is being editted
@@ -378,7 +385,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
         preRegEditObj = objName if (self.preRegEditOldObj) else newObjName
 
         newPart = copy.deepcopy(part)
-        self.editRegisters(modName, newPart, preRegEditObj, sectionName, self._preRegEditFilters)
+        self.editTexRegisters(modName, newPart, preRegEditObj, sectionName, self._preRegEditFilters)
 
         for varName, varValue, keyInd, orderInd in newPart:
             # filling in the hash
@@ -397,7 +404,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
                 newIndex = self._getIndex(newObjName.lower(), modName)
                 newPart.src[varName][keyInd] = (orderInd, f"{newIndex}")
 
-        self.editRegisters(modName, newPart, newObjName, sectionName, self._postRegEditFilters)
+        self.editTexRegisters(modName, newPart, newObjName, sectionName, self._postRegEditFilters)
         
         addFix = newPart.toStr(linePrefix = linePrefix)
         if (addFix != ""):

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjSplitFixer.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjSplitFixer.py
@@ -12,6 +12,7 @@
 ##### EndCredits
 
 ##### ExtImports
+import copy
 from typing import Dict, List, Optional
 ##### EndExtImports
 
@@ -20,6 +21,7 @@ from ....tools.ListTools import ListTools
 from .GIMIObjReplaceFixer import GIMIObjReplaceFixer
 from ..iniParsers.GIMIObjParser import GIMIObjParser
 from .regEditFilters.BaseRegEditFilter import BaseRegEditFilter
+from .regEditFilters.RegEditFilter import RegEditFilter
 from .regEditFilters.RegRemap import RegRemap
 from .regEditFilters.RegNewVals import RegNewVals
 from .regEditFilters.RegRemove import RegRemove
@@ -98,11 +100,17 @@ class GIMIObjSplitFixer(GIMIObjReplaceFixer):
         reference the original mod objects of the mod to be fixed or the new mod objects of the fixed mods :raw-html:`<br />` :raw-html:`<br />`
 
         **Default**: ``False``
+
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
     """
 
     def __init__(self, parser: GIMIObjParser, objs: Dict[str, List[str]], preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, 
-                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, preRegEditOldObj: bool = False):
-        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj)
+                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, preRegEditOldObj: bool = False, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
+        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj, postModelRegEditFilters = postModelRegEditFilters)
         self.objs = objs
 
 

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/BaseRegEditFilter.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/BaseRegEditFilter.py
@@ -17,9 +17,9 @@ from typing import TYPE_CHECKING
 
 ##### LocalImports
 from ....iftemplate.IfContentPart import IfContentPart
-from ...ModType import ModType
 
 if (TYPE_CHECKING):
+    from ...ModType import ModType
     from ..GIMIObjReplaceFixer import GIMIObjReplaceFixer
 ##### EndLocalImports
 
@@ -37,7 +37,7 @@ class BaseRegEditFilter():
 
         pass
 
-    def edit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def edit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
         """
         Edits the registers for the current :class:`IfContentPart`
 

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegEditFilter.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegEditFilter.py
@@ -18,9 +18,10 @@ from typing import TYPE_CHECKING
 ##### LocalImports
 from .BaseRegEditFilter import BaseRegEditFilter
 from ....iftemplate.IfContentPart import IfContentPart
-from ...ModType import ModType
 
 if (TYPE_CHECKING):
+    from ...ModType import ModType
+    from ..BaseIniFixer import BaseIniFixer
     from ..GIMIObjReplaceFixer import GIMIObjReplaceFixer
 ##### EndLocalImports
 
@@ -40,7 +41,7 @@ class RegEditFilter(BaseRegEditFilter):
 
         pass
 
-    def edit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def edit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
         """
         Edits the registers for the current :class:`IfContentPart`. Includes boilerplate of clearing all saved states and handling texture adds/edits
 
@@ -76,7 +77,7 @@ class RegEditFilter(BaseRegEditFilter):
         self.handleTexEdit(part, modType, fixModName, obj, sectionName, fixer)
         return result
 
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "BaseIniFixer") -> IfContentPart:
         """
         The main function to edit the registers for the current :class:`IfContentPart`
 
@@ -94,7 +95,7 @@ class RegEditFilter(BaseRegEditFilter):
         obj: :class:`str`
             The name of the mod object being fixed
 
-        fixer: :class:`GIMIObjReplaceFixer`
+        fixer: :class:`BaseIniFixer`
             The fixer that is editting the registers
 
         Returns 
@@ -105,7 +106,7 @@ class RegEditFilter(BaseRegEditFilter):
 
         pass
 
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         """
         Does any post-processing on the added textures of the corresponding :class:`GIMIObjReplaceFixer`
 
@@ -129,7 +130,7 @@ class RegEditFilter(BaseRegEditFilter):
 
         pass
 
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         """
         Does any post-processing on the added textures of the corresponding :class:`GIMIObjReplaceFixer`
 

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegNewVals.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegNewVals.py
@@ -18,9 +18,10 @@ from typing import Optional, Dict, TYPE_CHECKING, Union, Callable
 ##### LocalImports
 from .RegEditFilter import RegEditFilter
 from ....iftemplate.IfContentPart import IfContentPart
-from ...ModType import ModType
 
 if (TYPE_CHECKING):
+    from ...ModType import ModType
+    from ..BaseIniFixer import BaseIniFixer
     from ..GIMIObjReplaceFixer import GIMIObjReplaceFixer
 ##### EndLocalImports
 
@@ -77,7 +78,7 @@ class RegNewVals(RegEditFilter):
     def clear(self):
         self._regUpdates = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "BaseIniFixer") -> IfContentPart:
         try:
             self._regUpdates = self.vals[obj]
         except KeyError:
@@ -86,11 +87,11 @@ class RegNewVals(RegEditFilter):
         part.replaceVals(self._regUpdates, addNewKVPs = False)
         return part
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regUpdates is not None):
             fixer._currentTexAddsRegs = fixer._currentTexAddsRegs.difference(set(self._regUpdates.keys()))
 
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regUpdates is not None):
             fixer._currentTexEditRegs = fixer._currentTexEditRegs.difference(set(self._regUpdates.keys()))
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegRemap.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegRemap.py
@@ -18,9 +18,10 @@ from typing import Optional, Dict, List, Set, TYPE_CHECKING, Any
 ##### LocalImports
 from .RegEditFilter import RegEditFilter
 from ....iftemplate.IfContentPart import IfContentPart
-from ...ModType import ModType
 
 if (TYPE_CHECKING):
+    from ...ModType import ModType
+    from ..BaseIniFixer import BaseIniFixer
     from ..GIMIObjReplaceFixer import GIMIObjReplaceFixer
 ##### EndLocalImports
 
@@ -71,7 +72,7 @@ class RegRemap(RegEditFilter):
     def clear(self):
         self._regRemap = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "sBaseIniFixer") -> IfContentPart:
         try:
             self._regRemap = self.remap[obj]
         except KeyError:
@@ -96,7 +97,7 @@ class RegRemap(RegEditFilter):
             for newReg in newRegs:
                 currentTexRegData[newReg] = currentTexRegData[reg]
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         addedTextures = None
         try:
             addedTextures = fixer.addedTextures[obj]
@@ -106,6 +107,6 @@ class RegRemap(RegEditFilter):
         self._handleTex(fixer._currentTexAddsRegs, addedTextures)
 
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         self._handleTex(fixer._currentTexEditRegs, fixer._currentRegTexEdits)
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegRemove.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegRemove.py
@@ -18,9 +18,10 @@ from typing import Optional, Dict, Set, TYPE_CHECKING
 ##### LocalImports
 from .RegEditFilter import RegEditFilter
 from ....iftemplate.IfContentPart import IfContentPart
-from ...ModType import ModType
 
 if (TYPE_CHECKING):
+    from ...ModType import ModType
+    from ..BaseIniFixer import BaseIniFixer
     from ..GIMIObjReplaceFixer import GIMIObjReplaceFixer
 ##### EndLocalImports
 
@@ -85,7 +86,7 @@ class RegRemove(RegEditFilter):
     def clear(self):
         self._regRemove = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "BaseIniFixer") -> IfContentPart:
         try:
             self._regRemove = self.remove[obj]
         except KeyError:
@@ -102,11 +103,11 @@ class RegRemove(RegEditFilter):
 
         return regs.difference(removedRegs)
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regRemove is not None):
             fixer._currentTexAddsRegs = self._handleTex(part, fixer._currentTexAddsRegs)
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regRemove is not None):
             fixer._currentTexEditRegs = self._handleTex(part, fixer._currentTexEditRegs)
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegTexAdd.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegTexAdd.py
@@ -19,9 +19,9 @@ from typing import Optional, Dict, Tuple, TYPE_CHECKING
 from .RegEditFilter import RegEditFilter
 from ....iftemplate.IfContentPart import IfContentPart
 from ...texEditors.TexCreator import TexCreator
-from ...ModType import ModType
 
 if (TYPE_CHECKING):
+    from ...ModType import ModType
     from ..GIMIObjReplaceFixer import GIMIObjReplaceFixer
 ##### EndLocalImports
 
@@ -83,7 +83,7 @@ class RegTexAdd(RegEditFilter):
     def clear(self):
         self._regAddVals = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
         texAdds = None
         try:
             texAdds = self.textures[obj]
@@ -112,11 +112,11 @@ class RegTexAdd(RegEditFilter):
         part.replaceVals(self._regAddVals, addNewKVPs = self.mustAdd)
         return part
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regAddVals is not None):
             fixer._currentTexAddsRegs.update(set(self._regAddVals.keys()))
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regAddVals is not None):
             fixer._currentTexEditRegs = fixer._currentTexEditRegs.difference(set(self._regAddVals.keys()))
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegTexEdit.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegTexEdit.py
@@ -20,9 +20,9 @@ from .....tools.ListTools import ListTools
 from .....tools.DictTools import DictTools
 from .RegEditFilter import RegEditFilter
 from ....iftemplate.IfContentPart import IfContentPart
-from ...ModType import ModType
 
 if (TYPE_CHECKING):
+    from ...ModType import ModType
     from ..GIMIObjReplaceFixer import GIMIObjReplaceFixer
 ##### EndLocalImports
 
@@ -124,7 +124,7 @@ class RegTexEdit(RegEditFilter):
             result[newReg] = texRemapFixName
             fixer._currentRegTexEdits[newReg] = (texTypeName, currentRegResource)
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
         texEdits = None
         try:
             texEdits = fixer._parser.texEdits[obj]
@@ -137,10 +137,10 @@ class RegTexEdit(RegEditFilter):
         part.replaceVals(self._regEditVals, addNewKVPs = True)
         return part
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         return
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regEditVals is not None):
             fixer._currentTexEditRegs.update(set(self._regEditVals.keys()))
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/HashTools.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/HashTools.py
@@ -12,7 +12,7 @@
 ##### EndCredits
 
 ##### ExtImports
-from typing import Hashable, Callable, Optional, Dict, Union
+from typing import Hashable, Callable, Optional, Dict
 import hashlib
 import json
 ##### EndExtImports

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Sunday, May 18, 2025 01:12:05.860 AM UTC
-# Run Hash: 9763c429-2622-46a9-a791-eddede5cd803
+# Datetime Ran: Sunday, May 18, 2025 12:54:33.217 PM UTC
+# Run Hash: 880a55e9-b4c4-4e23-8747-3344f99f4492
 # 
 # **********************************
 # ================
@@ -32,8 +32,8 @@
 #
 # Version: 4.3.6
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Sunday, May 18, 2025 01:12:05.860 AM UTC
-# Build Hash: 3a10cf09-1db1-4b17-96df-4a8d1bf6f5f6
+# Datetime Compiled: Sunday, May 18, 2025 12:54:33.217 PM UTC
+# Build Hash: 9f22a04c-8d75-4729-83b5-5546fbb3735e
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Sunday, May 18, 2025 01:12:05.860 AM UTC
-# Run Hash: 9763c429-2622-46a9-a791-eddede5cd803
+# Datetime Ran: Sunday, May 18, 2025 12:54:33.217 PM UTC
+# Run Hash: 880a55e9-b4c4-4e23-8747-3344f99f4492
 # 
 # **********************************
 # ================
@@ -32,8 +32,8 @@
 #
 # Version: 4.3.6
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Sunday, May 18, 2025 01:12:05.860 AM UTC
-# Build Hash: 3a10cf09-1db1-4b17-96df-4a8d1bf6f5f6
+# Datetime Compiled: Sunday, May 18, 2025 12:54:33.217 PM UTC
+# Build Hash: 9f22a04c-8d75-4729-83b5-5546fbb3735e
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Sunday, May 18, 2025 01:12:04.726 AM UTC
-# Run Hash: bce6a7e5-90e4-4103-ba91-f77a5cdb4a0b
+# Datetime Ran: Sunday, May 18, 2025 12:54:32.100 PM UTC
+# Run Hash: 6aa03715-a087-45fc-b378-1fc64186ec19
 # 
 # *******************************
 # ================
@@ -35,8 +35,8 @@
 #
 # Version: 4.3.6
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Sunday, May 18, 2025 01:12:04.726 AM UTC
-# Build Hash: 0620b7af-9967-4b94-91cf-d63ac7feb145
+# Datetime Compiled: Sunday, May 18, 2025 12:54:32.100 PM UTC
+# Build Hash: 389296ef-de5b-407c-92e9-b7fe48a40ee0
 #
 # *********************************
 #
@@ -11787,6 +11787,176 @@ class IniFixBuilder(Builder[Callable[[], Tuple[BaseIniFixer, List[Any], Dict[str
         return super().build(parser)
 
 
+class BaseRegEditFilter():
+    """
+    Base class for editting registers within an :class:`IfContentPart`
+    """
+
+    def clear(self):
+        """
+        Clears any saved state within this class
+        """
+
+        pass
+
+    def edit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+        """
+        Edits the registers for the current :class:`IfContentPart`
+
+        Parameters
+        ----------
+        part: :class:`IfContentPart`
+            The part of the :class:`IfTemplate` that is being editted
+
+        modType: :class:`ModType`
+            The type of mod that is being fix from
+
+        fixModName: :class:`str`
+            The name of the mod to fix to
+
+        obj: :class:`str`
+            The name of the mod object being fixed
+
+        fixer: :class:`GIMIObjReplaceFixer`
+            The fixer that is editting the registers
+
+        Returns 
+        -------
+        :class:`IfContentPart`
+            The resultant part of the :class:`IfTemplate` that got its registers editted
+        """
+
+        self.clear()
+
+
+class RegEditFilter(BaseRegEditFilter):
+    """
+    This class inherits from :class:`BaseRegEditFilter`
+
+    class for editting registers within an :class:`IfContentPart`
+    """
+
+    def clear(self):
+        """
+        Clears any saved state within this class
+        """
+
+        pass
+
+    def edit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+        """
+        Edits the registers for the current :class:`IfContentPart`. Includes boilerplate of clearing all saved states and handling texture adds/edits
+
+        .. note::
+            If you are inheriting this class, you probably want to override the :meth:`RegEditFilter._editReg` method instead
+
+        Parameters
+        ----------
+        part: :class:`IfContentPart`
+            The part of the :class:`IfTemplate` that is being editted
+
+        modType: :class:`ModType`
+            The type of mod that is being fix from
+
+        fixModName: :class:`str`
+            The name of the mod to fix to
+
+        obj: :class:`str`
+            The name of the mod object being fixed
+
+        fixer: :class:`GIMIObjReplaceFixer`
+            The fixer that is editting the registers
+
+        Returns 
+        -------
+        :class:`IfContentPart`
+            The resultant part of the :class:`IfTemplate` that got its registers editted
+        """
+
+        self.clear()
+        result = self._editReg(part, modType, fixModName, obj, sectionName, fixer)
+        self.handleTexAdd(part, modType, fixModName, obj, sectionName, fixer)
+        self.handleTexEdit(part, modType, fixModName, obj, sectionName, fixer)
+        return result
+
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "BaseIniFixer") -> IfContentPart:
+        """
+        The main function to edit the registers for the current :class:`IfContentPart`
+
+        Parameters
+        ----------
+        part: :class:`IfContentPart`
+            The part of the :class:`IfTemplate` that is being editted
+
+        modType: :class:`ModType`
+            The type of mod that is being fix from
+
+        fixModName: :class:`str`
+            The name of the mod to fix to
+
+        obj: :class:`str`
+            The name of the mod object being fixed
+
+        fixer: :class:`BaseIniFixer`
+            The fixer that is editting the registers
+
+        Returns 
+        -------
+        :class:`IfContentPart`
+            The resultant part of the :class:`IfTemplate` that got its registers editted
+        """
+
+        pass
+
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+        """
+        Does any post-processing on the added textures of the corresponding :class:`GIMIObjReplaceFixer`
+
+        Parameters
+        ----------
+        part: :class:`IfContentPart`
+            The part of the :class:`IfTemplate` that is being editted
+
+        modType: :class:`ModType`
+            The type of mod that is being fix from
+
+        fixModName: :class:`str`
+            The name of the mod to fix to
+
+        obj: :class:`str`
+            The name of the mod object being fixed
+
+        fixer: :class:`GIMIObjReplaceFixer`
+            The fixer that is editting the registers
+        """
+
+        pass
+
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+        """
+        Does any post-processing on the added textures of the corresponding :class:`GIMIObjReplaceFixer`
+
+        Parameters
+        ----------
+        part: :class:`IfContentPart`
+            The part of the :class:`IfTemplate` that is being editted
+
+        modType: :class:`ModType`
+            The type of mod that is being fix from
+
+        fixModName: :class:`str`
+            The name of the mod to fix to
+
+        obj: :class:`str`
+            The name of the mod object being fixed
+
+        fixer: :class:`GIMIObjReplaceFixer`
+            The fixer that is editting the registers
+        """
+
+        pass
+
+
 class GIMIFixer(BaseIniFixer):
     """
     This class inherits from :class:`BaseIniFixer`
@@ -11797,10 +11967,23 @@ class GIMIFixer(BaseIniFixer):
     ----------
     parser: :class:`GIMIParser`
         The associated parser to retrieve data for the fix
+
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
+    Attributes
+    ----------
+    postModelRegEditFilters: List[:class:`RegEditFilter`]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list.
     """
 
-    def __init__(self, parser: GIMIParser):
+    def __init__(self, parser: GIMIParser, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
         super().__init__(parser)
+        self.postModelRegEditFilters = [] if (postModelRegEditFilters is None) else postModelRegEditFilters
 
     def clear(self):
         super().clear()
@@ -11812,6 +11995,39 @@ class GIMIFixer(BaseIniFixer):
         if (modName in modsToFix):
             return self._getRemapName(sectionName, modName, sectionGraph = sectionGraph, remapNameFunc = remapNameFunc)
         return sectionName
+    
+    def editModelRegisters(self, modName: str, part: IfContentPart, modelPartName: str, sectionName: str, filters: List[RegEditFilter]):
+        """
+        Edits the registers for a :class:`IfContentPart` in the .VB or .IB `sections`_
+
+        .. note::
+            For details on steps of how the registers are editted, see :class:`GIMIObjReplaceFixer`
+
+        Parameters
+        ----------
+        modName: :class:`str`
+            The name of the mod to fix to
+
+        part: :class:`IfContentPart`
+            The part that is being editted
+
+        modelPartName: :class:`str`
+            The name of the part within the .VB or .IB `sections`_
+
+        sectionName: :class:`str`
+            The name of the `section`_ the part belongs to
+
+        filters: List[:class:`BaseRegEditFilter`]
+            The filters used for editting the registers
+        """
+
+        modType = self._iniFile.availableType
+        if (modType is None):
+            return
+        
+        for filter in filters:
+            filter.clear()
+            filter._editReg(part, modType, modName, modelPartName, sectionName, self)
 
     def _fillTextureOverrideRemapBlend(self, modName: str, sectionName: str, part: IfContentPart, partIndex: int, linePrefix: str, origSectionName: str) -> str:
         """
@@ -11847,43 +12063,39 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.blendCommandsGraph)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the vb1 resource
             elif (varName == IniKeywords.Vb1.value):
                 blendName = varValue
                 remapBlendName = self._getRemapName(blendName, modName, sectionGraph = self._parser.blendResourceCommandsGraph, remapNameFunc = self._iniFile.getRemapBlendResourceName)
-                fixStr = f'{IniKeywords.Vb1.value} = {remapBlendName}'
-                addFix += f"{linePrefix}{fixStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{remapBlendName}")
 
             # filling in the handling
             elif (varName == IniKeywords.Handling.value):
-                fixStr = f'{IniKeywords.Handling.value} = skip'
-                addFix += f"{linePrefix}{fixStr}\n"
-
-            # filling in the draw value
-            elif (varName == IniKeywords.Draw.value):
-                fixStr = f'{IniKeywords.Draw.value} = {varValue}'
-                addFix += f"{linePrefix}{fixStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"skip")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"index")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Blend.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     
@@ -11921,33 +12133,35 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.positionCommandsGraph, remapNameFunc = self._iniFile.getRemapPositionName)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the vb0 resource
             elif (varName == IniKeywords.Vb0.value):
                 positionName = varValue
                 remapPositionName = self._getBufRemapName(positionName, modName, self._parser._positionEditModsToFix, sectionGraph = self._parser.positionResourceCommandsGraph, remapNameFunc = self._iniFile.getRemapPositionResourceName)
-                fixStr = f'{IniKeywords.Vb0.value} = {remapPositionName}'
-                addFix += f"{linePrefix}{fixStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{remapPositionName}")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{index}")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Position.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     
@@ -11985,26 +12199,29 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.texcoordCommandsGraph, remapNameFunc = self._iniFile.getRemapTexcoordName)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{index}")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Texcoord.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     
@@ -12042,26 +12259,29 @@ class GIMIFixer(BaseIniFixer):
         """
 
         addFix = ""
+        newPart = copy.deepcopy(part)
 
-        for varName, varValue, _, _ in part:
+        for varName, varValue, keyInd, orderInd in newPart:
             # filling in the subcommand
             if (varName == IniKeywords.Run.value):
                 subCommandName = self._getRemapName(varValue, modName, sectionGraph = self._parser.ibCommandsGraph, remapNameFunc = self._iniFile.getRemapIbName)
-                subCommandStr = f"{IniKeywords.Run.value} = {subCommandName}"
-                addFix += f"{linePrefix}{subCommandStr}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{subCommandName}")
 
             # filling in the hash
             elif (varName == IniKeywords.Hash.value):
                 hash = self._getHashReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.Hash.value} = {hash}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{hash}")
 
             # filling in the indices
             elif (varName == IniKeywords.MatchFirstIndex.value):
                 index = self._getIndexReplacement(varValue, modName)
-                addFix += f"{linePrefix}{IniKeywords.MatchFirstIndex.value} = {index}\n"
+                newPart.src[varName][keyInd] = (orderInd, f"{index}")
 
-            else:
-                addFix += f"{linePrefix}{varName} = {varValue}\n"
+        self.editModelRegisters(modName, newPart, IniKeywords.Ib.value, sectionName, self.postModelRegEditFilters)
+
+        addFix = newPart.toStr(linePrefix = linePrefix)
+        if (addFix != ""):
+            addFix += "\n"
                 
         return addFix
     
@@ -15768,176 +15988,6 @@ class HashTools():
         return cls._genericBase64ShortUniqueHash(obj, cls._base64DeterministicShortUniqueHashFunc, cls.Base64SmallDeterministicHashMap)
 
 
-class BaseRegEditFilter():
-    """
-    Base class for editting registers within an :class:`IfContentPart`
-    """
-
-    def clear(self):
-        """
-        Clears any saved state within this class
-        """
-
-        pass
-
-    def edit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
-        """
-        Edits the registers for the current :class:`IfContentPart`
-
-        Parameters
-        ----------
-        part: :class:`IfContentPart`
-            The part of the :class:`IfTemplate` that is being editted
-
-        modType: :class:`ModType`
-            The type of mod that is being fix from
-
-        fixModName: :class:`str`
-            The name of the mod to fix to
-
-        obj: :class:`str`
-            The name of the mod object being fixed
-
-        fixer: :class:`GIMIObjReplaceFixer`
-            The fixer that is editting the registers
-
-        Returns 
-        -------
-        :class:`IfContentPart`
-            The resultant part of the :class:`IfTemplate` that got its registers editted
-        """
-
-        self.clear()
-
-
-class RegEditFilter(BaseRegEditFilter):
-    """
-    This class inherits from :class:`BaseRegEditFilter`
-
-    class for editting registers within an :class:`IfContentPart`
-    """
-
-    def clear(self):
-        """
-        Clears any saved state within this class
-        """
-
-        pass
-
-    def edit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
-        """
-        Edits the registers for the current :class:`IfContentPart`. Includes boilerplate of clearing all saved states and handling texture adds/edits
-
-        .. note::
-            If you are inheriting this class, you probably want to override the :meth:`RegEditFilter._editReg` method instead
-
-        Parameters
-        ----------
-        part: :class:`IfContentPart`
-            The part of the :class:`IfTemplate` that is being editted
-
-        modType: :class:`ModType`
-            The type of mod that is being fix from
-
-        fixModName: :class:`str`
-            The name of the mod to fix to
-
-        obj: :class:`str`
-            The name of the mod object being fixed
-
-        fixer: :class:`GIMIObjReplaceFixer`
-            The fixer that is editting the registers
-
-        Returns 
-        -------
-        :class:`IfContentPart`
-            The resultant part of the :class:`IfTemplate` that got its registers editted
-        """
-
-        self.clear()
-        result = self._editReg(part, modType, fixModName, obj, sectionName, fixer)
-        self.handleTexAdd(part, modType, fixModName, obj, sectionName, fixer)
-        self.handleTexEdit(part, modType, fixModName, obj, sectionName, fixer)
-        return result
-
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
-        """
-        The main function to edit the registers for the current :class:`IfContentPart`
-
-        Parameters
-        ----------
-        part: :class:`IfContentPart`
-            The part of the :class:`IfTemplate` that is being editted
-
-        modType: :class:`ModType`
-            The type of mod that is being fix from
-
-        fixModName: :class:`str`
-            The name of the mod to fix to
-
-        obj: :class:`str`
-            The name of the mod object being fixed
-
-        fixer: :class:`GIMIObjReplaceFixer`
-            The fixer that is editting the registers
-
-        Returns 
-        -------
-        :class:`IfContentPart`
-            The resultant part of the :class:`IfTemplate` that got its registers editted
-        """
-
-        pass
-
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
-        """
-        Does any post-processing on the added textures of the corresponding :class:`GIMIObjReplaceFixer`
-
-        Parameters
-        ----------
-        part: :class:`IfContentPart`
-            The part of the :class:`IfTemplate` that is being editted
-
-        modType: :class:`ModType`
-            The type of mod that is being fix from
-
-        fixModName: :class:`str`
-            The name of the mod to fix to
-
-        obj: :class:`str`
-            The name of the mod object being fixed
-
-        fixer: :class:`GIMIObjReplaceFixer`
-            The fixer that is editting the registers
-        """
-
-        pass
-
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
-        """
-        Does any post-processing on the added textures of the corresponding :class:`GIMIObjReplaceFixer`
-
-        Parameters
-        ----------
-        part: :class:`IfContentPart`
-            The part of the :class:`IfTemplate` that is being editted
-
-        modType: :class:`ModType`
-            The type of mod that is being fix from
-
-        fixModName: :class:`str`
-            The name of the mod to fix to
-
-        obj: :class:`str`
-            The name of the mod object being fixed
-
-        fixer: :class:`GIMIObjReplaceFixer`
-            The fixer that is editting the registers
-        """
-
-        pass
-
-
 class TexCreator(BaseTexEditor):
     """
     This class inherits from :class:`BaseTexEditor`
@@ -16017,7 +16067,7 @@ class RegTexAdd(RegEditFilter):
     def clear(self):
         self._regAddVals = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
         texAdds = None
         try:
             texAdds = self.textures[obj]
@@ -16046,11 +16096,11 @@ class RegTexAdd(RegEditFilter):
         part.replaceVals(self._regAddVals, addNewKVPs = self.mustAdd)
         return part
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regAddVals is not None):
             fixer._currentTexAddsRegs.update(set(self._regAddVals.keys()))
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regAddVals is not None):
             fixer._currentTexEditRegs = fixer._currentTexEditRegs.difference(set(self._regAddVals.keys()))
 
@@ -16092,6 +16142,12 @@ class GIMIObjReplaceFixer(GIMIFixer):
 
         **Default**: ``True``
 
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
     Attributes
     ----------
     preRegEditOldObj: :class:`bool`
@@ -16113,8 +16169,8 @@ class GIMIObjReplaceFixer(GIMIFixer):
     """
 
     def __init__(self, parser: GIMIObjParser, preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None,
-                 preRegEditOldObj: bool = True):
-        super().__init__(parser)
+                 preRegEditOldObj: bool = True, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
+        super().__init__(parser, postModelRegEditFilters = postModelRegEditFilters)
         self._texInds: Dict[str, Dict[str, int]] = {}
         self._texEditRemapNames: Dict[str, Dict[str, str]] = {}
         self._texAddRemapNames: Dict[str, Dict[str, str]] = {}
@@ -16279,9 +16335,9 @@ class GIMIObjReplaceFixer(GIMIFixer):
     def getObjHashType(self):
         return "ib"
     
-    def editRegisters(self, modName: str, part: IfContentPart, obj: str, sectionName: str, filters: List[BaseRegEditFilter]):
+    def editTexRegisters(self, modName: str, part: IfContentPart, obj: str, sectionName: str, filters: List[BaseRegEditFilter]):
         """
-        Edits the registers for a :class:`IfContentPart`
+        Edits the registers for a :class:`IfContentPart` in the texture related `section`_
 
         .. note::
             For details on steps of how the registers are editted, see :class:`GIMIObjReplaceFixer`
@@ -16289,7 +16345,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
         Parameters
         ----------
         modName: :class:`str`
-            The name of the mod
+            The name of the mod to fix to
 
         part: :class:`IfContentPart`
             The part that is being editted
@@ -16396,7 +16452,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
         preRegEditObj = objName if (self.preRegEditOldObj) else newObjName
 
         newPart = copy.deepcopy(part)
-        self.editRegisters(modName, newPart, preRegEditObj, sectionName, self._preRegEditFilters)
+        self.editTexRegisters(modName, newPart, preRegEditObj, sectionName, self._preRegEditFilters)
 
         for varName, varValue, keyInd, orderInd in newPart:
             # filling in the hash
@@ -16415,7 +16471,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
                 newIndex = self._getIndex(newObjName.lower(), modName)
                 newPart.src[varName][keyInd] = (orderInd, f"{newIndex}")
 
-        self.editRegisters(modName, newPart, newObjName, sectionName, self._postRegEditFilters)
+        self.editTexRegisters(modName, newPart, newObjName, sectionName, self._postRegEditFilters)
         
         addFix = newPart.toStr(linePrefix = linePrefix)
         if (addFix != ""):
@@ -16739,7 +16795,7 @@ class RegRemap(RegEditFilter):
     def clear(self):
         self._regRemap = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "sBaseIniFixer") -> IfContentPart:
         try:
             self._regRemap = self.remap[obj]
         except KeyError:
@@ -16764,7 +16820,7 @@ class RegRemap(RegEditFilter):
             for newReg in newRegs:
                 currentTexRegData[newReg] = currentTexRegData[reg]
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         addedTextures = None
         try:
             addedTextures = fixer.addedTextures[obj]
@@ -16774,7 +16830,7 @@ class RegRemap(RegEditFilter):
         self._handleTex(fixer._currentTexAddsRegs, addedTextures)
 
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         self._handleTex(fixer._currentTexEditRegs, fixer._currentRegTexEdits)
 
 
@@ -16829,7 +16885,7 @@ class RegNewVals(RegEditFilter):
     def clear(self):
         self._regUpdates = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "BaseIniFixer") -> IfContentPart:
         try:
             self._regUpdates = self.vals[obj]
         except KeyError:
@@ -16838,11 +16894,11 @@ class RegNewVals(RegEditFilter):
         part.replaceVals(self._regUpdates, addNewKVPs = False)
         return part
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regUpdates is not None):
             fixer._currentTexAddsRegs = fixer._currentTexAddsRegs.difference(set(self._regUpdates.keys()))
 
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regUpdates is not None):
             fixer._currentTexEditRegs = fixer._currentTexEditRegs.difference(set(self._regUpdates.keys()))
 
@@ -16906,7 +16962,7 @@ class RegRemove(RegEditFilter):
     def clear(self):
         self._regRemove = None
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "BaseIniFixer") -> IfContentPart:
         try:
             self._regRemove = self.remove[obj]
         except KeyError:
@@ -16923,11 +16979,11 @@ class RegRemove(RegEditFilter):
 
         return regs.difference(removedRegs)
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regRemove is not None):
             fixer._currentTexAddsRegs = self._handleTex(part, fixer._currentTexAddsRegs)
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regRemove is not None):
             fixer._currentTexEditRegs = self._handleTex(part, fixer._currentTexEditRegs)
 
@@ -17002,11 +17058,17 @@ class GIMIObjSplitFixer(GIMIObjReplaceFixer):
         reference the original mod objects of the mod to be fixed or the new mod objects of the fixed mods :raw-html:`<br />` :raw-html:`<br />`
 
         **Default**: ``False``
+
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
     """
 
     def __init__(self, parser: GIMIObjParser, objs: Dict[str, List[str]], preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, 
-                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, preRegEditOldObj: bool = False):
-        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj)
+                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, preRegEditOldObj: bool = False, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
+        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj, postModelRegEditFilters = postModelRegEditFilters)
         self.objs = objs
 
 
@@ -17140,11 +17202,17 @@ class GIMIObjRegEditFixer(GIMIObjSplitFixer):
         :raw-html:`<br />`
 
         **Default**: ``None``
+
+    postModelRegEditFilters: Optional[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod
+        Filters are executed based on the order specified in the list. :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
     """
 
     def __init__(self, parser: GIMIObjParser, preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, 
-                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None):
-        super().__init__(parser, {}, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters)
+                 postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postModelRegEditFilters: Optional[List[RegEditFilter]] = None):
+        super().__init__(parser, {}, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, postModelRegEditFilters = postModelRegEditFilters)
 
         parserObjs = sorted(self._parser.objs)
         for obj in parserObjs:
@@ -17216,6 +17284,11 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
 
         **Default**: ``None``
 
+    iniPostModelRegEditFilters: Optional[List[List[:class:`RegEditFilter`]]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod for each .ini file :raw-html:`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
     Attributes
     ----------
     _targetObjs: Dict[:class:`str`, :class:`str`]
@@ -17225,12 +17298,22 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
 
     copyPreamble: :class:`str`
         Any text we want to put before the text of the newly generated .ini file variations
+
+    iniPostModelRegEditFilters: List[List[:class:`RegEditFilter`]]
+        Filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod for each .ini file
+
+    postModelRegEditFilters: List[:class:`RegEditFilter`]
+        The filters used to edit the registers of a certain :class:`IfContentPart` for the `sections`_ related to the .VB or .IB of a mod for the current .ini file being generated
     """
 
     def __init__(self, parser: GIMIObjParser, objs: Dict[str, List[str]], copyPreamble: str = "", 
-                 preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None):
+                 preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None,
+                 iniPostModelRegEditFilters: Optional[List[List[RegEditFilter]]] = None):
+
+        self.iniPostModelRegEditFilters = [] if (iniPostModelRegEditFilters is None) else iniPostModelRegEditFilters
+
         super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters)
-        self._targetObjs: Dict[str, str] = {}
+        self._targetObjs: List[Tuple[str, str]]
         self._maxObjsToMergeLen = 0
         self._sectionsToIgnore: Set[str] = set()
         self.objs = objs
@@ -17277,8 +17360,7 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
             fix += "\n"
 
         # retrieve the fix for all the merged mod objects
-        for objToFix in self._targetObjs:
-            fixedObj = self._targetObjs[objToFix]
+        for objToFix, fixedObj in self._targetObjs:
             objGraph = self._parser.objGraphs[objToFix]
 
             if (not objGraph.sections):
@@ -17301,12 +17383,20 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
     
     # _getCurrentTargetObjs(ind): Retrieves the current mod objects to show in the current .ini file for each merged mod object
     def _getCurrentTargetObjs(self, ind: int):
-        self._targetObjs = {}
+        self._targetObjs = []
         for mergedObj in self._objs:
             objsToMerge = self._objs[mergedObj]
             if (ind <= len(objsToMerge) - 1):
                 objToMerge = objsToMerge[ind]
-                self._targetObjs[objToMerge] = mergedObj
+                self._targetObjs.append((objToMerge, mergedObj))
+
+    # _getCurrentModelRegEditFilters(ind): Retrieves the current register editting filters to edit the sections to the .ib/.vb of the mod
+    def _getCurrentModelRegEditFilters(self, ind: int):
+        if (len(self.iniPostModelRegEditFilters) <= ind):
+            self.postModelRegEditFilters = []
+            return
+        
+        self.postModelRegEditFilters = self.iniPostModelRegEditFilters[ind]
 
     # _getIgnoredSections(): Retrieves which sections to ignore when performing the normal part of the fix
     def _getIgnoredSections(self):
@@ -17342,6 +17432,8 @@ class GIMIObjMergeFixer(GIMIObjReplaceFixer):
         texEditModels = {}
         for i in range(self._maxObjsToMergeLen):
             self._getCurrentTargetObjs(i)
+            self._getCurrentModelRegEditFilters(i)
+
             if (i > 0 and iniFilePath is not None):
                 iniFilePath.baseName = f"{iniBaseName}{FileSuffixes.RemapFixCopy.value}{i}"
 
@@ -17562,7 +17654,7 @@ class RegTexEdit(RegEditFilter):
             result[newReg] = texRemapFixName
             fixer._currentRegTexEdits[newReg] = (texTypeName, currentRegResource)
     
-    def _editReg(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
+    def _editReg(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer") -> IfContentPart:
         texEdits = None
         try:
             texEdits = fixer._parser.texEdits[obj]
@@ -17575,10 +17667,10 @@ class RegTexEdit(RegEditFilter):
         part.replaceVals(self._regEditVals, addNewKVPs = True)
         return part
     
-    def handleTexAdd(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexAdd(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         return
     
-    def handleTexEdit(self, part: IfContentPart, modType: ModType, fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
+    def handleTexEdit(self, part: IfContentPart, modType: "ModType", fixModName: str, obj: str, sectionName: str, fixer: "GIMIObjReplaceFixer"):
         if (self._regEditVals is not None):
             fixer._currentTexEditRegs.update(set(self._regEditVals.keys()))
 
@@ -17758,6 +17850,27 @@ class IniFixBuilderFuncs():
                     RegNewVals(vals = {"head": {"ps-t0": "null"}}),
                     RegTexAdd(textures = {"dress": {"ps-t0": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapBlue.value))}}, mustAdd = False)
                 ]})
+    
+    @classmethod
+    def hutao5_6(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head"], "body": ["body", "body"], "dress": ["body", "body"], "extra": ["head", "head"]}],
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"},
+                                        "body": {"ps-t2", "ps-t3"}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"extra": {"ps-t0", "ps-t1"}}),
+                    RegNewVals(vals = {"extra": {IniKeywords.Ib.value: "null"}, 
+                                       "dress": {IniKeywords.Ib.value: "null"}}),
+                    RegTexEdit(textures = {"TransparentHeadDiffuse": ["ps-t0"]}),
+                    RegRemap(remap = {"head": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2"]},
+                                        "dress": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2"]}}),
+                    RegNewVals(vals = {"head": {"ps-t0": "null"}}),
+                    RegTexAdd(textures = {"dress": {"ps-t0": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapBlue.value))}}, mustAdd = False)
+                ],
+                "iniPostModelRegEditFilters": [[RegNewVals(vals = {IniKeywords.Ib.value: {"hash": "null"}})], []]})
     
     @classmethod
     def jean4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18150,6 +18263,9 @@ IniFixBuilderData = {
     5.5: {
         ModTypeNames.Jean.value: IniFixBuilderFuncs.jean5_5,
         ModTypeNames.JeanCN.value: IniFixBuilderFuncs.jeanCN5_5
+    },
+    5.6: {
+        ModTypeNames.HuTao.value: IniFixBuilderFuncs.hutao5_6
     }
 }
 

--- a/Docs/src/api.rst
+++ b/Docs/src/api.rst
@@ -1744,6 +1744,28 @@ TextTools
 
 :raw-html:`<br />`
 
+IntTools
+~~~~~~~~~
+
+.. attributetable:: FixRaidenBoss2.IntTools
+
+.. autoclass:: FixRaidenBoss2.IntTools
+    :members:
+    :private-members:
+
+:raw-html:`<br />`
+
+HashTools
+~~~~~~~~~
+
+.. attributetable:: FixRaidenBoss2.HashTools
+
+.. autoclass:: FixRaidenBoss2.HashTools
+    :members:
+    :private-members:
+
+:raw-html:`<br />`
+
 FilePath
 ~~~~~~~~~
 

--- a/Docs/src/apiExamples.rst
+++ b/Docs/src/apiExamples.rst
@@ -229,7 +229,6 @@ Only Fix a .ini File Given the File Path
             vb1 = ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend
         endif
 
-
         [ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend]
         type = Buffer
         stride = 32
@@ -477,7 +476,6 @@ The code below will add the lines that make up the fix to the end of the origina
             vb1 = ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend
         endif
 
-
         [ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend]
         type = Buffer
         stride = 32
@@ -643,7 +641,6 @@ The code below will only generate the necessary lines needed to fix the .ini fil
         if $swapoffice == 0 && $swapglasses == 0
             vb1 = ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend
         endif
-
 
         [ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend]
         type = Buffer
@@ -1785,7 +1782,6 @@ This example is the combined result of these 2 examples:
             vb1 = ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend
         endif
 
-
         [ResourceGIMINeedsResourcesToAllStartWithResourceRaidenBossRemapBlend]
         type = Buffer
         stride = 32
@@ -1901,7 +1897,6 @@ By default, the mod will show on both the original character and the remapped ch
         handling = skip
         draw = 21916,0
 
-
         [TextureOverrideAmberCNBodyAmberRemapFix]
         hash = b03c7e30
         match_first_index = 5670
@@ -1910,7 +1905,6 @@ By default, the mod will show on both the original character and the remapped ch
         ps-t1 = ResourceAmberCNBodyLightMap
         ps-t2 = ResourceAmberCNBodyMetalMap
         ps-t3 = ResourceAmberCNBodyShadowRamp
-
 
         [ResourceAmberCNAmberRemapBlend]
         type = Buffer
@@ -2013,7 +2007,6 @@ This example shows a weird use case of wanting to fix the .ini file to an older 
         handling = skip
         draw = 21916,0
 
-
         [TextureOverrideAmberCNBodyAmberRemapFix]
         hash = 9976d124
         match_first_index = 5670
@@ -2022,7 +2015,6 @@ This example shows a weird use case of wanting to fix the .ini file to an older 
         ps-t1 = ResourceAmberCNBodyLightMap
         ps-t2 = ResourceAmberCNBodyMetalMap
         ps-t3 = ResourceAmberCNBodyShadowRamp
-
 
         [ResourceAmberCNAmberRemapBlend]
         type = Buffer
@@ -2463,7 +2455,6 @@ In this example, by running the program called `example.py`, the fix will start 
                 draw = 21916,0
             endif
 
-
             [ResourceRaidenShogunRaidenBossRemapBlend.0]
             type = Buffer
             stride = 32
@@ -2506,7 +2497,6 @@ In this example, by running the program called `example.py`, the fix will start 
             handling = skip
             draw = 21916,0
 
-
             [ResourceRaidenShogunRaidenBossRemapBlend]
             type = Buffer
             stride = 32
@@ -2544,7 +2534,6 @@ In this example, by running the program called `example.py`, the fix will start 
             handling = skip
             draw = 21916,0
 
-
             [ResourceRaidenShogunRaidenBossRemapBlend]
             type = Buffer
             stride = 32
@@ -2581,7 +2570,6 @@ In this example, by running the program called `example.py`, the fix will start 
             vb1 = ResourceRaidenShogunRaidenBossRemapBlend
             handling = skip
             draw = 21916,0
-
 
             [ResourceRaidenShogunRaidenBossRemapBlend]
             type = Buffer
@@ -3395,12 +3383,10 @@ Reference: https://gamebanana.com/posts/12191289
             handling = skip
             draw = 41553,0
 
-
             [TextureOverrideKiraraKiraraBootsRemapIB]
             hash = 846979e2
             handling = skip
             drawindexed = auto
-
 
             [TextureOverrideKiraraPositionKiraraBootsRemapFix]
             hash = f8013ba9
@@ -3444,14 +3430,13 @@ Reference: https://gamebanana.com/posts/12191289
             ps-t2 = ResourceKiraraBodyLightMap
             run = CommandList\global\ORFix\ORFix
 
-
             [ResourceKiraraKiraraBootsRemapBlend]
             type = Buffer
             stride = 32
             filename = KiraraKiraraBootsRemapBlend.buf
 
             [ResourceKiraraBodyDarkenDiffuseKiraraBootsRemapTex0]
-            filename = KiraraBootsBodyRemapTex0.dds
+            filename = KiraraBootsBodyRemapTexBJ6 Gns.dds
 
             ; ***********************
 
@@ -3601,12 +3586,10 @@ Reference: https://gamebanana.com/posts/12191289
             handling = skip
             draw = 41553,0
 
-
             [TextureOverrideKiraraKiraraBootsRemapIB]
             hash = 846979e2
             handling = skip
             drawindexed = auto
-
 
             [TextureOverrideKiraraPositionKiraraBootsRemapFix]
             hash = f8013ba9
@@ -3641,14 +3624,13 @@ Reference: https://gamebanana.com/posts/12191289
             ps-t2 = ResourceKiraraBodyLightMap
             run = CommandList\global\ORFix\ORFix
 
-
             [ResourceKiraraKiraraBootsRemapBlend]
             type = Buffer
             stride = 32
             filename = KiraraKiraraBootsRemapBlend.buf
 
             [ResourceKiraraBodyDarkenDiffuseKiraraBootsRemapTex1]
-            filename = KiraraBootsBodyRemapTex0.dds
+            filename = KiraraBootsBodyRemapTexBJ6 Gns.dds
 
             ; ***********************
 
@@ -4014,17 +3996,14 @@ The example below shows how to forcibly use the strategy for remapping Rosaria o
             hash = HashNotFound
             vb0 = ResourceKiraraPosition
 
-
             [TextureOverrideKiraraRosariaCNRemapTexcoord]
             hash = HashNotFound
             vb1 = ResourceKiraraTexcoord
-
 
             [TextureOverrideKiraraRosariaCNRemapIB]
             hash = HashNotFound
             handling = skip
             drawindexed = auto
-
 
             [TextureOverrideKiraraBodyRosariaCNRemapFix]
             hash = bdca273e
@@ -4052,7 +4031,6 @@ The example below shows how to forcibly use the strategy for remapping Rosaria o
             ps-t1 = ResourceKiraraHeadDiffuse
             ps-t2 = ResourceKiraraHeadLightMap
             run = CommandList\global\ORFix\ORFix
-
 
             [ResourceKiraraRosariaCNRemapBlend]
             type = Buffer
@@ -4659,11 +4637,15 @@ Mods for Shenhe and Raiden will not be fixed.
             |    |     |
             |    |     +--> Cutesy.dds
             |    |     |
-            |    |     +--> KeqingOpulentDressRemapTex0.dds
+            |    |     +--> KeqingOpulentDressRemapTexHl4 BUx.dds
+            |    |     |
+            |    |     +--> KeqingOpulentDressRemapTexNQe BUx.dds
             |    |     |
             |    |     +--> CutiePie.dds
             |    |     |
-            |    |     +--> KeqingOpulentHeadRemapTex0.dds
+            |    |     +--> KeqingOpulentHeadRemapTexCKA HQ7.dds
+            |    |     |
+            |    |     +--> KeqingOpulentHeadRemapTexKZA HQ7.dds
             |    |
             |    +--> Buffs
             |          |
@@ -4726,7 +4708,6 @@ Mods for Shenhe and Raiden will not be fixed.
             handling = skip
             draw = 21916,0
 
-
             [ResourceAmberAmberCNRemapBlend]
             type = Buffer
             stride = 32
@@ -4764,7 +4745,6 @@ Mods for Shenhe and Raiden will not be fixed.
             handling = skip
             draw = 21916,0
 
-
             [ResourceJeanJeanCNRemapBlend]
             type = Buffer
             stride = 32
@@ -4777,7 +4757,6 @@ Mods for Shenhe and Raiden will not be fixed.
             vb1 = ResourceJeanJeanSeaRemapBlend
             handling = skip
             draw = 21916,0
-
 
             [ResourceJeanJeanSeaRemapBlend]
             type = Buffer
@@ -4826,14 +4805,12 @@ Mods for Shenhe and Raiden will not be fixed.
             handling = skip
             draw = 21916,0
 
-
             [TextureOverrideJeanBodyJeanCNRemapFix]
             hash = aad861e0
             match_first_index = 7779
             ib = ResourceJeanSeaBodyIB
             ps-t0 = ResourceJeanSeaBodyDiffuse
             ps-t1 = ResourceJeanSeaBodyLightMap
-
 
             [ResourceJeanJeanCNRemapBlend]
             type = Buffer
@@ -4847,7 +4824,6 @@ Mods for Shenhe and Raiden will not be fixed.
             vb1 = ResourceJeanJeanSeaRemapBlend
             handling = skip
             draw = 21916,0
-
 
             [TextureOverrideJeanBodyJeanSeaRemapFix]
             hash = 69c0c24e
@@ -4863,14 +4839,13 @@ Mods for Shenhe and Raiden will not be fixed.
             ps-t0 = ResourceJeanSeaBodyDiffuse
             ps-t1 = ResourceJeanSeaBodyLightMap
 
-
             [ResourceJeanJeanSeaRemapBlend]
             type = Buffer
             stride = 32
             filename = ../SmolJeanJeanSeaRemapBlend.buf
 
             [ResourceJeanBodyShadeLightMapJeanSeaRemapTex0]
-            filename = ../JeanSeaBodyRemapTex0.dds
+            filename = ../JeanSeaBodyRemapTexPK_ BNl.dds
 
             ; *******************
 
@@ -4949,7 +4924,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 draw = 21916,0
             endif
 
-
             [TextureOverrideJeanBodyJeanCNRemapFix]
             if $swapvar == 0
                 hash = aad861e0
@@ -4964,7 +4938,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 ps-t0 = ResourceJeanSeaBodyDiffuse
                 ps-t1 = ResourceJeanSeaBodyLightMap
             endif
-
 
             [ResourceJeanJeanCNRemapBlend.0]
             type = Buffer
@@ -4989,7 +4962,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 handling = skip
                 draw = 21916,0
             endif
-
 
             [TextureOverrideJeanBodyJeanSeaRemapFix]
             if $swapvar == 0
@@ -5021,7 +4993,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 ps-t1 = ResourceJeanSeaBodyLightMap
             endif
 
-
             [ResourceJeanJeanSeaRemapBlend.0]
             type = Buffer
             stride = 32
@@ -5033,7 +5004,7 @@ Mods for Shenhe and Raiden will not be fixed.
             filename = SmolJean/CuteJeanJeanSeaRemapBlend.buf
 
             [ResourceJeanBodyShadeLightMapJeanSeaRemapTex0]
-            filename = JeanSeaBodyRemapTex0.dds
+            filename = JeanSeaBodyRemapTexPK_ BNl.dds
 
             ; *******************
 
@@ -5160,7 +5131,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 draw = 21916,0
             endif
 
-
             [TextureOverrideKeqingBodyKeqingOpulentRemapFix]
             hash = 7c6fc8c3
             match_first_index = 19623
@@ -5197,7 +5167,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 ps-t1 = ResourceKeqingDressLightMap.3
             endif
 
-
             [ResourceKeqingKeqingOpulentRemapBlend.0]
             type = Buffer
             stride = 32
@@ -5209,10 +5178,10 @@ Mods for Shenhe and Raiden will not be fixed.
             filename = ../Buffs/SmallerHitboxesKeqingOpulentRemapBlend.buf
 
             [ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex0]
-            filename = KeqingOpulentDressRemapTex0.dds
+            filename = KeqingOpulentDressRemapTexNQe BUx.dds
 
             [ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex1]
-            filename = KeqingOpulentDressRemapTex0.dds
+            filename = KeqingOpulentDressRemapTexHl4 BUx.dds
 
             ; *************************
 
@@ -5361,7 +5330,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 draw = 21916,0
             endif
 
-
             [TextureOverrideKeqingBodyKeqingOpulentRemapFix]
             hash = 7c6fc8c3
             match_first_index = 19623
@@ -5398,7 +5366,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 ps-t1 = ResourceKeqingHeadLightMap.3
             endif
 
-
             [ResourceKeqingKeqingOpulentRemapBlend.0]
             type = Buffer
             stride = 32
@@ -5410,10 +5377,10 @@ Mods for Shenhe and Raiden will not be fixed.
             filename = ../Buffs/SmallerHitboxesKeqingOpulentRemapBlend.buf
 
             [ResourceKeqingHeadOpaqueHeadDiffuseKeqingOpulentRemapTex0]
-            filename = KeqingOpulentHeadRemapTex0.dds
+            filename = KeqingOpulentHeadRemapTexCKA HQ7.dds
 
             [ResourceKeqingHeadOpaqueHeadDiffuseKeqingOpulentRemapTex1]
-            filename = KeqingOpulentHeadRemapTex0.dds
+            filename = KeqingOpulentHeadRemapTexKZA HQ7.dds
 
             ; *************************
 
@@ -5522,7 +5489,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 draw = 21916,0
             endif
 
-
             [TextureOverrideKeqingBodyKeqingOpulentRemapFix]
             hash = 7c6fc8c3
             match_first_index = 19623
@@ -5559,7 +5525,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 ps-t1 = ResourceKeqingDressLightMap.3
             endif
 
-
             [ResourceKeqingKeqingOpulentRemapBlend.0]
             type = Buffer
             stride = 32
@@ -5571,10 +5536,10 @@ Mods for Shenhe and Raiden will not be fixed.
             filename = ../Buffs/SmallerHitboxesKeqingOpulentRemapBlend.buf
 
             [ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex0]
-            filename = KeqingOpulentDressRemapTex0.dds
+            filename = KeqingOpulentDressRemapTexNQe BUx.dds
 
             [ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex1]
-            filename = KeqingOpulentDressRemapTex0.dds
+            filename = KeqingOpulentDressRemapTexHl4 BUx.dds
 
             ; *************************
 
@@ -5705,7 +5670,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 draw = 21916,0
             endif
 
-
             [TextureOverrideKeqingBodyKeqingOpulentRemapFix]
             hash = 7c6fc8c3
             match_first_index = 19623
@@ -5723,7 +5687,6 @@ Mods for Shenhe and Raiden will not be fixed.
                 ps-t0 = ResourceKeqingBodyDiffuse.3
                 ps-t1 = ResourceKeqingBodyLightMap.3
             endif
-
 
             [ResourceKeqingKeqingOpulentRemapBlend.0]
             type = Buffer
@@ -6142,7 +6105,6 @@ The example below shows fixing entire mods where the mod only shows on the remap
                 draw = 21916,0
             endif
 
-
             [TextureOverrideKeqingBodyKeqingOpulentRemapFix]
             hash = 7c6fc8c3
             match_first_index = 19623
@@ -6179,7 +6141,6 @@ The example below shows fixing entire mods where the mod only shows on the remap
                 ps-t1 = ResourceKeqingDressLightMap.3
             endif
 
-
             [ResourceKeqingKeqingOpulentRemapBlend.0]
             type = Buffer
             stride = 32
@@ -6191,10 +6152,10 @@ The example below shows fixing entire mods where the mod only shows on the remap
             filename = ../Buffs/SmallerHitboxesKeqingOpulentRemapBlend.buf
 
             [ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex0]
-            filename = KeqingOpulentDressRemapTex0.dds
+            filename = KeqingOpulentDressRemapTexNQe BUx.dds
 
             [ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex1]
-            filename = KeqingOpulentDressRemapTex0.dds
+            filename = KeqingOpulentDressRemapTexHl4 BUx.dds
 
             ; *************************
 
@@ -6325,7 +6286,6 @@ The example below shows fixing entire mods where the mod only shows on the remap
                 draw = 21916,0
             endif
 
-
             [TextureOverrideKeqingBodyKeqingOpulentRemapFix]
             hash = 7c6fc8c3
             match_first_index = 19623
@@ -6343,7 +6303,6 @@ The example below shows fixing entire mods where the mod only shows on the remap
                 ps-t0 = ResourceKeqingBodyDiffuse.3
                 ps-t1 = ResourceKeqingBodyLightMap.3
             endif
-
 
             [ResourceKeqingKeqingOpulentRemapBlend.0]
             type = Buffer


### PR DESCRIPTION
For some reason, these lines that are typically in a GIMI mod is not working properly for `HuTao --> CherryHuTao`:

<br>

```ini
[TextureOverride.*IB.*]
hash = ...
handling = skip
drawindexed = auto
...
```

<br>

I suspect the error is caused by a model change to CherryHuTao, with the model change hitting some unhandled edge case for GIMI.

A weird solution would be to duplicate the fixed .ini file and disabling the section by the name `TextureOverride.*IB.*` for the original .ini file by setting the key-value pair of `hash`to `null` for those sections

Since `HuTao --> CherryHuTao` originally use a [GIMIObjSplitFixer](https://anime-game-remap.readthedocs.io/en/latest/api.html#gimiobjsplitfixer), but we need the multiple file property of a [GIMIMergeFixer](https://anime-game-remap.readthedocs.io/en/latest/api.html#gimiobjmergefixer), we relaxed the restriction on [GIMIMergeFixer](https://anime-game-remap.readthedocs.io/en/latest/api.html#gimiobjmergefixer) to allow the same source mod object to merge to many different fixed mod objects. So [GIMIMergeFixer](https://anime-game-remap.readthedocs.io/en/latest/api.html#gimiobjmergefixer) became a more powerful version of  [GIMIObjSplitFixer](https://anime-game-remap.readthedocs.io/en/latest/api.html#gimiobjsplitfixer)

If this change works, we essentially exposed some of the internals of GIMI's file search algorithm for how it searches files within a folder (sinks within the file graph).

We observe the following properties:
- The order of the file search within a folder is deterministic
- The order is probably either alphabetical order or reverse alphabetical order