### PR TITLE
Release 4.4

### DIFF
--- a/Anime Game Remap (for all users)/api/README.md
+++ b/Anime Game Remap (for all users)/api/README.md
@@ -37,6 +37,11 @@ The ***Official*** library to help remap the mods installed on a character onto 
 
 <br>
 
+## Documentation
+https://anime-game-remap.readthedocs.io/en/latest/
+
+<br>
+
 ## Requirements 
 - [Python (version 3.6 and up)](https://www.python.org/downloads/)
 
@@ -50,7 +55,7 @@ The ***Official*** library to help remap the mods installed on a character onto 
 
 | | |
 | --- | --- |
-| [C++ Distributables 14.0 or greater](https://visualstudio.microsoft.com/visual-cpp-build-tools/) | Used for better optimization of classifying what mod belongs to some .ini file |
+| [C++ Distributables 14.0 or greater](https://visualstudio.microsoft.com/visual-cpp-build-tools/) or some sort of C Compiler | Used for better optimization of classifying what mod belongs to some .ini file |
 
 <br>
 <br>

--- a/Anime Game Remap (for all users)/apiMirror/README.md
+++ b/Anime Game Remap (for all users)/apiMirror/README.md
@@ -37,6 +37,11 @@ The ***Official*** library to help remap the mods installed on a character onto 
 
 <br>
 
+## Documentation
+https://anime-game-remap.readthedocs.io/en/latest/
+
+<br>
+
 ## Requirements 
 - [Python (version 3.6 and up)](https://www.python.org/downloads/)
 
@@ -50,7 +55,7 @@ The ***Official*** library to help remap the mods installed on a character onto 
 
 | | |
 | --- | --- |
-| [C++ Distributables 14.0 or greater](https://visualstudio.microsoft.com/visual-cpp-build-tools/) | Used for better optimization of classifying what mod belongs to some .ini file |
+| [C++ Distributables 14.0 or greater](https://visualstudio.microsoft.com/visual-cpp-build-tools/) or some sort of C Compiler | Used for better optimization of classifying what mod belongs to some .ini file |
 
 <br>
 <br>

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Friday, May 23, 2025 11:19:43.999 PM UTC
-# Run Hash: 25f5389d-6ebc-4572-9572-ce47e778d8e5
+# Datetime Ran: Saturday, May 24, 2025 12:02:53.943 AM UTC
+# Run Hash: 33906d24-6f18-4cf9-a5b7-1c6bc52f8d8a
 # 
 # **********************************
 # ================
@@ -32,8 +32,8 @@
 #
 # Version: 4.4.0
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Friday, May 23, 2025 11:19:43.999 PM UTC
-# Build Hash: e0e7dd8d-44ae-4f12-8a5c-c6da83ba94ae
+# Datetime Compiled: Saturday, May 24, 2025 12:02:53.943 AM UTC
+# Build Hash: a86c2e4f-5054-45e6-ad67-e7257fb89f68
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Friday, May 23, 2025 11:19:43.999 PM UTC
-# Run Hash: 25f5389d-6ebc-4572-9572-ce47e778d8e5
+# Datetime Ran: Saturday, May 24, 2025 12:02:53.943 AM UTC
+# Run Hash: 33906d24-6f18-4cf9-a5b7-1c6bc52f8d8a
 # 
 # **********************************
 # ================
@@ -32,8 +32,8 @@
 #
 # Version: 4.4.0
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Friday, May 23, 2025 11:19:43.999 PM UTC
-# Build Hash: e0e7dd8d-44ae-4f12-8a5c-c6da83ba94ae
+# Datetime Compiled: Saturday, May 24, 2025 12:02:53.943 AM UTC
+# Build Hash: a86c2e4f-5054-45e6-ad67-e7257fb89f68
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Friday, May 23, 2025 11:19:43.303 PM UTC
-# Run Hash: 3c695545-b2ce-443e-9779-a0c5dfb83bf2
+# Datetime Ran: Saturday, May 24, 2025 12:02:53.153 AM UTC
+# Run Hash: 27648243-1225-4644-8636-317fa1c21970
 # 
 # *******************************
 # ================
@@ -35,8 +35,8 @@
 #
 # Version: 4.4.0
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Friday, May 23, 2025 11:19:43.303 PM UTC
-# Build Hash: ffb5d35e-726e-4d86-9b06-7f1cd1a42d5b
+# Datetime Compiled: Saturday, May 24, 2025 12:02:53.153 AM UTC
+# Build Hash: 656d9c91-6d76-43bd-8a7f-34e2bcd6942d
 #
 # *********************************
 #

--- a/Docs/src/apiExamples.rst
+++ b/Docs/src/apiExamples.rst
@@ -3230,7 +3230,7 @@ Reference: https://gamebanana.com/posts/12191289
             |
             +--> Neko.dds
             |
-            +--> KiraraBootsBodyRemapTex0.dds
+            +--> KiraraBootsBodyRemapTexBJ6 Gns.dds.dds
             |
             +--> KiraraBlend.buf
             |
@@ -4607,7 +4607,7 @@ Mods for Shenhe and Raiden will not be fixed.
             |    |    |
             |    |    +--> CuteJeanJeanSeaRemapBlend.buf
             |    |
-            |    +--> JeanSeaBodyRemapTex0.dds
+            |    +--> JeanSeaBodyRemapTexPK_ BNl.dds
             |    |
             |    +--> merged.ini
             |    |
@@ -5976,19 +5976,15 @@ The example below shows fixing entire mods where the mod only shows on the remap
             |    |
             |    +--> CatGirl.dds
             |    |
-            |    +--> CatGirlKeqingOpulentRemapTex0.dds
+            |    +--> KeqingOpulentDressRemapTexNQe BUx.dds
             |    |
             |    +--> Patootie.dds
             |    |
-            |    +--> PatootieKeqingOpulentRemapTex0.dds
+            |    +--> KeqingOpulentDressRemapTexHl4 BUx.dds
             |    |
             |    +--> Cutesy.dds
             |    |
-            |    +--> CutesyKeqingOpulentRemapTex0.dds
-            |    |
             |    +--> CutiePie.dds
-            |    |
-            |    +--> CutiePieKeqingOpulentRemapTex0.dds
             |    |
             |    +--> example.py
             |

--- a/Docs/src/index.rst
+++ b/Docs/src/index.rst
@@ -71,7 +71,7 @@ Optional Requirements
     You do not need to install any of the below dependencies, but you can optionally install them, if you want,
     for some slightly better performance
 
-* `C++ Distributables 14.0 or greater <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_
+* `C++ Distributables 14.0 or greater <https://visualstudio.microsoft.com/visual-cpp-build-tools/>`_ or some sort of C Compiler
 
 `Used for better optimization of classifying what mod belongs to some .ini file`
 


### PR DESCRIPTION
## Features

- Added the last remaps for:
   - **Lisa** (Special thanks to [Halflight#2803](https://discordlookup.com/user/370149469779394562) for providing the vertex group remap! ❤)
   - **Kaeya**
- Automate file downloads for mods that do not include all the required files
   - You can specify how the software checks for file downloads using the `-dl` or `--download` option
   - All download modes for the option can be viewed [here](https://anime-game-remap.readthedocs.io/en/latest/commandOpts.html#download-modes)
- Added tool to port mods back into Blender!? *(Preview of AGConvert!?!)*
   - Download for such a tool by [visiting this download page](https://github.com/nhok0169/Anime-Game-Remap/blob/nhok0169/Tools/ModToDumpConverter/GI/GIModToDumpConverter.ipynb)
   - Also we have [another tool to transform dumped assets into a mod here](https://github.com/nhok0169/Anime-Game-Remap/blob/nhok0169/Tools/DumpToModConverter/GI/GIDumpToModConverter.ipynb)
- Shorten file names for texture edits
- Add option to specify proxy URL using the `-p` or `--proxy` option for those whose internet connection must go through a proxy server (eg. using corporate computers)
- Added tutorial on [how to find vertex group remaps](https://anime-game-remap.readthedocs.io/en/latest/findVertexGroupRemap.html)
- Added a brief [wiki section](https://github.com/nhok0169/Anime-Game-Remap/wiki) for how to make changes in the project

<br>

## Bugs
- Fix up Body and Dress of JeanSea due to game model updates
- Fix up HuTao remaps breaking due to game model updates
- Fix Blue outlines appearing on CherryHuTao's hair
- Fix up the `-ho`/`--hideOriginal` option for Jean
- Fix some `RemapTex.dds` texture files not being removed when undoing a fix

<br>

## Optimizations
- Optimized texture edits to run more at the C level
- Optimized how files are searched