### PR TITLE
Disable escape characters in regex strings

### DIFF
--- a/Anime Game Remap (for all users)/api/pyproject.toml
+++ b/Anime Game Remap (for all users)/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "4.4.0"
+version = "4.4.1"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniClassifiers/IniClassifier.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniClassifiers/IniClassifier.py
@@ -81,7 +81,7 @@ class IniClassifier(BaseIniClassifier):
     IsFixedPattern = re.compile(r"\s*\[.*" + f"{IniKeywords.Remap.value}({IniKeywords.Blend.value}|{IniKeywords.Position.value}|{IniKeywords.Ib.value}|dl|tex|fix".lower() + r").*\]")
     IsModPattern = re.compile(r"\s*\[.*(" + f"{IniKeywords.Blend.value}|{IniKeywords.Position.value}".lower() + r").*\]")
     IsModOrIsFixedPattern = re.compile(r"(" + f"{IniKeywords.Blend.value}|{IniKeywords.Position.value}|{IniKeywords.Remap.value}(fix|tex|{IniKeywords.Ib.value})".lower() + r")")
-    RemapFixSuffixPattern = re.compile(IniKeywords.RemapFix.value.lower() + ".*\]")
+    RemapFixSuffixPattern = re.compile(IniKeywords.RemapFix.value.lower() + r".*\]")
 
     IsFixedKeywords = {IniKeywords.RemapBlend.value.lower(), IniKeywords.RemapFix.value.lower(), IniKeywords.RemapPosition.value.lower(),
                        IniKeywords.RemapTex.value.lower(), IniKeywords.RemapDL.value.lower(), IniKeywords.RemapIb.value.lower(), IniKeywords.RemapTexcoord.value.lower()}

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniRemovers/IniRemover.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniRemovers/IniRemover.py
@@ -42,8 +42,8 @@ class IniRemover(BaseIniRemover):
         The .ini file to remove the fix from
     """
 
-    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}((.|\n)*?); {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*)|(; {IniBoilerPlate.DefaultHeading.value.open()}((.|\n)*?); {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*)")
-    _removalPattern = re.compile(f"^\s*\[.*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value + r"|Fix|Tex).*\]")
+    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*)|(; {IniBoilerPlate.DefaultHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*)")
+    _removalPattern = re.compile(r"^\s*\[" + f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value + r"|Fix|Tex).*\]")
     _sectionRemovalPattern = re.compile(f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value +  r"|Fix|Tex).*")
     _remapTexRemovalPattern = re.compile(IniKeywords.Resource.value + f".*" + IniKeywords.RemapTex.value + r".*")
     _remapDLRemovalPattern = re.compile(IniKeywords.Resource.value + f".*" + IniKeywords.RemapDL.value + r".*")

--- a/Anime Game Remap (for all users)/apiMirror/pyproject.toml
+++ b/Anime Game Remap (for all users)/apiMirror/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AnimeGameRemap"
-version = "4.4.0"
+version = "4.4.1"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	"FixRaidenBoss2==4.4.0"
+	"FixRaidenBoss2==4.4.1"
 ]
 
 [project.urls]

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, May 24, 2025 01:54:01.890 AM UTC
-# Run Hash: f1b8f860-f67f-48a8-bd4d-e0f0e4d7a8b0
+# Datetime Ran: Saturday, May 24, 2025 06:58:54.494 PM UTC
+# Run Hash: bde0ba3f-b9c5-4639-b21e-4befb7b72804
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.4.0
+# Version: 4.4.1
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, May 24, 2025 01:54:01.890 AM UTC
-# Build Hash: 244b8212-77c5-4f18-92af-b75c2e7785ce
+# Datetime Compiled: Saturday, May 24, 2025 06:58:54.494 PM UTC
+# Build Hash: 54a48172-3842-42a4-989e-0e4d49659b08
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, May 24, 2025 01:54:01.890 AM UTC
-# Run Hash: f1b8f860-f67f-48a8-bd4d-e0f0e4d7a8b0
+# Datetime Ran: Saturday, May 24, 2025 06:58:54.494 PM UTC
+# Run Hash: bde0ba3f-b9c5-4639-b21e-4befb7b72804
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.4.0
+# Version: 4.4.1
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, May 24, 2025 01:54:01.890 AM UTC
-# Build Hash: 244b8212-77c5-4f18-92af-b75c2e7785ce
+# Datetime Compiled: Saturday, May 24, 2025 06:58:54.494 PM UTC
+# Build Hash: 54a48172-3842-42a4-989e-0e4d49659b08
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, May 24, 2025 01:54:01.325 AM UTC
-# Run Hash: 55aea2fa-06f6-4ac9-9637-2201e308202c
+# Datetime Ran: Saturday, May 24, 2025 06:58:52.506 PM UTC
+# Run Hash: 3a8cdc8f-ac72-42c1-b7f2-331a15383c65
 # 
 # *******************************
 # ================
@@ -33,10 +33,10 @@
 #
 # ***** AG Remap Script Stats *****
 #
-# Version: 4.4.0
+# Version: 4.4.1
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, May 24, 2025 01:54:01.325 AM UTC
-# Build Hash: 67075523-5ac3-4aaa-86cf-81c5219b6fdd
+# Datetime Compiled: Saturday, May 24, 2025 06:58:52.506 PM UTC
+# Build Hash: 26467a52-5e99-49f1-8ae2-a2a6f5550802
 #
 # *********************************
 #
@@ -8533,8 +8533,8 @@ class IniRemover(BaseIniRemover):
         The .ini file to remove the fix from
     """
 
-    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}((.|\n)*?); {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*)|(; {IniBoilerPlate.DefaultHeading.value.open()}((.|\n)*?); {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*)")
-    _removalPattern = re.compile(f"^\s*\[.*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value + r"|Fix|Tex).*\]")
+    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*)|(; {IniBoilerPlate.DefaultHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*)")
+    _removalPattern = re.compile(r"^\s*\[" + f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value + r"|Fix|Tex).*\]")
     _sectionRemovalPattern = re.compile(f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value +  r"|Fix|Tex).*")
     _remapTexRemovalPattern = re.compile(IniKeywords.Resource.value + f".*" + IniKeywords.RemapTex.value + r".*")
     _remapDLRemovalPattern = re.compile(IniKeywords.Resource.value + f".*" + IniKeywords.RemapDL.value + r".*")
@@ -21153,7 +21153,7 @@ class IniClassifier(BaseIniClassifier):
     IsFixedPattern = re.compile(r"\s*\[.*" + f"{IniKeywords.Remap.value}({IniKeywords.Blend.value}|{IniKeywords.Position.value}|{IniKeywords.Ib.value}|dl|tex|fix".lower() + r").*\]")
     IsModPattern = re.compile(r"\s*\[.*(" + f"{IniKeywords.Blend.value}|{IniKeywords.Position.value}".lower() + r").*\]")
     IsModOrIsFixedPattern = re.compile(r"(" + f"{IniKeywords.Blend.value}|{IniKeywords.Position.value}|{IniKeywords.Remap.value}(fix|tex|{IniKeywords.Ib.value})".lower() + r")")
-    RemapFixSuffixPattern = re.compile(IniKeywords.RemapFix.value.lower() + ".*\]")
+    RemapFixSuffixPattern = re.compile(IniKeywords.RemapFix.value.lower() + r".*\]")
 
     IsFixedKeywords = {IniKeywords.RemapBlend.value.lower(), IniKeywords.RemapFix.value.lower(), IniKeywords.RemapPosition.value.lower(),
                        IniKeywords.RemapTex.value.lower(), IniKeywords.RemapDL.value.lower(), IniKeywords.RemapIb.value.lower(), IniKeywords.RemapTexcoord.value.lower()}

--- a/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
+++ b/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
@@ -4,7 +4,7 @@ from ..softwareStats.SoftwareContributor import SoftwareContributor
 
 Title = "Anime Game Remap"
 ShortTitle = "AG Remap"
-APIVersion = "4.4.0"
+APIVersion = "4.4.1"
 
 Authors = {
     "Albert": SoftwareContributor("Albert Gold", discName = "albertgold", oldDisName = "Albert Gold#2696"),


### PR DESCRIPTION
For python 3.12+ seems like the regex library does not like having escape characters being parsed
https://stackoverflow.com/questions/52335970/how-to-fix-syntaxwarning-invalid-escape-sequence-in-python

To prevent such an issue, replace every instance of regex strings that reference an escape character to be surrounded in a raw string