### PR TITLE
Fix Ayaka remap's body from being grey

### DIFF
--- a/Anime Game Remap (for all users)/api/pyproject.toml
+++ b/Anime Game Remap (for all users)/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "4.4.3"
+version = "4.4.4"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
@@ -131,16 +131,18 @@ class IniFixBuilderFuncs():
     @classmethod
     def ayakaSpringbloom5_6(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjMergeFixer, 
-                [{"head": ["head", "head"], "body": ["body", "body"], "dress": ["dress", "dress"]}], 
+                [{"head": ["body", "body", "body"], "body": ["body", "head", "head"], "dress": ["dress", "dress", "dress"]}], 
                 {
                  "preRegEditFilters": [
                     RegRemove(remove = {"head": {"ps-t0", "ps-t3", "ResourceRefHeadDiffuse", "ResourceRefHeadLightMap", "$CharacterIB", ("run", cls._regValIsOrFix)},
                                         "body": {"ps-t0", "ResourceRefBodyDiffuse", "ResourceRefBodyLightMap", "$CharacterIB", ("run", cls._regValIsOrFix)},
                                         "dress": {"ps-t3", "ResourceRefDressDiffuse", "ResourceRefDressLightMap", "$CharacterIB", ("run", cls._regValIsOrFix)}}),
+                    RegTexEdit(textures = {"HeadShadeLightMap": ["ps-t2"]}),
                     RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1"]},
-                                        "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1"], "ps-t3": ["ps-t2"]}})
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1"], "ps-t3": ["ps-t2"]}})
                 ],
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = {IniKeywords.Ib.value: {"hash": "null"}})], []]})
+                "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
+                "iniPostModelRegEditFilters": [[RegNewVals(vals = {IniKeywords.Ib.value: {"hash": "null"}})], [], []]})
 
     
     @classmethod

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniParseBuilderData.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniParseBuilderData.py
@@ -87,10 +87,25 @@ class IniParseBuilderFuncs():
                 "objFileDownloads": {"head": FileDownloadData[4.0][ModTypeNames.Ayaka.value]["head"],
                                      "body": FileDownloadData[4.0][ModTypeNames.Ayaka.value]["body"],
                                      "dress": FileDownloadData[4.0][ModTypeNames.Ayaka.value]["dress"]}})
+    
+    @classmethod
+    def _ayakaSpringbloomEditLightMap5_6(cls, texFile: TextureFile):
+        alphaImg = texFile.img.getchannel('A')
+        alphaImg = alphaImg.point(lambda alphaPixel: Colour.boundColourChannel(alphaPixel + 200) if (alphaPixel <= 200) else alphaPixel)
+        texFile.img.putalpha(alphaImg)
 
     @classmethod
     def ayakaSpringbloom4_0(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
         return (GIMIObjParser, [{"head", "body", "dress"}], {})
+    
+    @classmethod
+    def ayakaSpringbloom5_6(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
+        return (GIMIObjParser, 
+                [{"head", "body", "dress"}], 
+                {"texEdits": {"head": {"ps-t2": {"HeadShadeLightMap": TexEditor(filters = [ColourReplaceFilter(Colour(0, 128, 0, 1), coloursToReplace = {ColourRange(Colour(0, 125, 0, 255), Colour(50, 160, 50, 255))}),
+                                                                                           ColourReplaceFilter(Colours.LightMapGreen.value, 
+                                                                                                               coloursToReplace = {ColourRange(Colour(0, 125, 0, 100), Colour(50, 160, 50, 254)),
+                                                                                                                                   ColourRange(Colour(0, 0, 0, 100), Colour(0, 0, 0, 200))})])}}}})
     
     @classmethod
     def arlecchino5_4(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
@@ -622,6 +637,7 @@ IniParseBuilderData = {
     5.4: {ModTypeNames.Arlecchino.value: IniParseBuilderFuncs.arlecchino5_4},
 
     5.5: {ModTypeNames.Jean.value: IniParseBuilderFuncs.jean5_5,
-          ModTypeNames.JeanCN.value: IniParseBuilderFuncs.jeanCN5_5}
+          ModTypeNames.JeanCN.value: IniParseBuilderFuncs.jeanCN5_5},
+    5.6: {ModTypeNames.AyakaSpringbloom.value: IniParseBuilderFuncs.ayakaSpringbloom5_6}
 }
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/texEditors/texFilters/ColourReplaceFilter.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/texEditors/texFilters/ColourReplaceFilter.py
@@ -124,7 +124,12 @@ class ColourReplaceFilter(BaseTexFilter):
                 blueMatch = blueImg.point(lambda bluePixel: Colour.boolToColourChannel(bluePixel >= colour.min.blue and bluePixel <= colour.max.blue)).convert(ImgFormats.Bit.value)
                 alphaMatch = alphaImg.point(lambda alphaPixel: Colour.boolToColourChannel(alphaPixel >= colour.min.alpha and alphaPixel <= colour.max.alpha)).convert(ImgFormats.Bit.value)
 
-            mask = ImageChops.logical_and(mask, redMatch) if (i > 0) else redMatch
+            if (i > 0):
+                mask = ImageChops.invert(mask)
+                mask = ImageChops.logical_and(mask, redMatch)
+            else:
+                mask = redMatch
+
             mask = ImageChops.logical_and(mask, greenMatch)
             mask = ImageChops.logical_and(mask, blueMatch)
             mask = ImageChops.logical_and(mask, alphaMatch)

--- a/Anime Game Remap (for all users)/apiMirror/pyproject.toml
+++ b/Anime Game Remap (for all users)/apiMirror/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AnimeGameRemap"
-version = "4.4.3"
+version = "4.4.4"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	"FixRaidenBoss2==4.4.3"
+	"FixRaidenBoss2==4.4.4"
 ]
 
 [project.urls]

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, May 24, 2025 08:38:27.806 PM UTC
-# Run Hash: d12fb596-cf7e-471f-b4a0-ff947ee9fced
+# Datetime Ran: Wednesday, May 28, 2025 08:04:29.477 PM UTC
+# Run Hash: b7b7c87b-3775-4e52-be0f-9591a329156a
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.4.3
+# Version: 4.4.4
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, May 24, 2025 08:38:27.806 PM UTC
-# Build Hash: f6c0efd5-e1bd-445b-a194-cf483a707504
+# Datetime Compiled: Wednesday, May 28, 2025 08:04:29.477 PM UTC
+# Build Hash: 58c242a0-f560-4594-8caa-7393ccfdb775
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, May 24, 2025 08:38:27.806 PM UTC
-# Run Hash: d12fb596-cf7e-471f-b4a0-ff947ee9fced
+# Datetime Ran: Wednesday, May 28, 2025 08:04:29.477 PM UTC
+# Run Hash: b7b7c87b-3775-4e52-be0f-9591a329156a
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.4.3
+# Version: 4.4.4
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, May 24, 2025 08:38:27.806 PM UTC
-# Build Hash: f6c0efd5-e1bd-445b-a194-cf483a707504
+# Datetime Compiled: Wednesday, May 28, 2025 08:04:29.477 PM UTC
+# Build Hash: 58c242a0-f560-4594-8caa-7393ccfdb775
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, May 24, 2025 08:38:26.829 PM UTC
-# Run Hash: 3d1d53e2-4b7b-49b1-962d-d8fb35a9999f
+# Datetime Ran: Wednesday, May 28, 2025 08:04:28.294 PM UTC
+# Run Hash: a24da740-7b43-4886-8d36-f54806c66127
 # 
 # *******************************
 # ================
@@ -33,10 +33,10 @@
 #
 # ***** AG Remap Script Stats *****
 #
-# Version: 4.4.3
+# Version: 4.4.4
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, May 24, 2025 08:38:26.829 PM UTC
-# Build Hash: 072dcc00-7bf1-4ecf-a04c-4ccdc8cf1d23
+# Datetime Compiled: Wednesday, May 28, 2025 08:04:28.294 PM UTC
+# Build Hash: c4fb4b59-726b-432d-96d8-70b9ebd2f2d9
 #
 # *********************************
 #
@@ -14516,7 +14516,12 @@ class ColourReplaceFilter(BaseTexFilter):
                 blueMatch = blueImg.point(lambda bluePixel: Colour.boolToColourChannel(bluePixel >= colour.min.blue and bluePixel <= colour.max.blue)).convert(ImgFormats.Bit.value)
                 alphaMatch = alphaImg.point(lambda alphaPixel: Colour.boolToColourChannel(alphaPixel >= colour.min.alpha and alphaPixel <= colour.max.alpha)).convert(ImgFormats.Bit.value)
 
-            mask = ImageChops.logical_and(mask, redMatch) if (i > 0) else redMatch
+            if (i > 0):
+                mask = ImageChops.invert(mask)
+                mask = ImageChops.logical_and(mask, redMatch)
+            else:
+                mask = redMatch
+
             mask = ImageChops.logical_and(mask, greenMatch)
             mask = ImageChops.logical_and(mask, blueMatch)
             mask = ImageChops.logical_and(mask, alphaMatch)
@@ -15244,10 +15249,25 @@ class IniParseBuilderFuncs():
                 "objFileDownloads": {"head": FileDownloadData[4.0][ModTypeNames.Ayaka.value]["head"],
                                      "body": FileDownloadData[4.0][ModTypeNames.Ayaka.value]["body"],
                                      "dress": FileDownloadData[4.0][ModTypeNames.Ayaka.value]["dress"]}})
+    
+    @classmethod
+    def _ayakaSpringbloomEditLightMap5_6(cls, texFile: TextureFile):
+        alphaImg = texFile.img.getchannel('A')
+        alphaImg = alphaImg.point(lambda alphaPixel: Colour.boundColourChannel(alphaPixel + 200) if (alphaPixel <= 200) else alphaPixel)
+        texFile.img.putalpha(alphaImg)
 
     @classmethod
     def ayakaSpringbloom4_0(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
         return (GIMIObjParser, [{"head", "body", "dress"}], {})
+    
+    @classmethod
+    def ayakaSpringbloom5_6(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
+        return (GIMIObjParser, 
+                [{"head", "body", "dress"}], 
+                {"texEdits": {"head": {"ps-t2": {"HeadShadeLightMap": TexEditor(filters = [ColourReplaceFilter(Colour(0, 128, 0, 1), coloursToReplace = {ColourRange(Colour(0, 125, 0, 255), Colour(50, 160, 50, 255))}),
+                                                                                           ColourReplaceFilter(Colours.LightMapGreen.value, 
+                                                                                                               coloursToReplace = {ColourRange(Colour(0, 125, 0, 100), Colour(50, 160, 50, 254)),
+                                                                                                                                   ColourRange(Colour(0, 0, 0, 100), Colour(0, 0, 0, 200))})])}}}})
     
     @classmethod
     def arlecchino5_4(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
@@ -15779,7 +15799,8 @@ IniParseBuilderData = {
     5.4: {ModTypeNames.Arlecchino.value: IniParseBuilderFuncs.arlecchino5_4},
 
     5.5: {ModTypeNames.Jean.value: IniParseBuilderFuncs.jean5_5,
-          ModTypeNames.JeanCN.value: IniParseBuilderFuncs.jeanCN5_5}
+          ModTypeNames.JeanCN.value: IniParseBuilderFuncs.jeanCN5_5},
+    5.6: {ModTypeNames.AyakaSpringbloom.value: IniParseBuilderFuncs.ayakaSpringbloom5_6}
 }
 
 
@@ -17863,16 +17884,18 @@ class IniFixBuilderFuncs():
     @classmethod
     def ayakaSpringbloom5_6(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjMergeFixer, 
-                [{"head": ["head", "head"], "body": ["body", "body"], "dress": ["dress", "dress"]}], 
+                [{"head": ["body", "body", "body"], "body": ["body", "head", "head"], "dress": ["dress", "dress", "dress"]}], 
                 {
                  "preRegEditFilters": [
                     RegRemove(remove = {"head": {"ps-t0", "ps-t3", "ResourceRefHeadDiffuse", "ResourceRefHeadLightMap", "$CharacterIB", ("run", cls._regValIsOrFix)},
                                         "body": {"ps-t0", "ResourceRefBodyDiffuse", "ResourceRefBodyLightMap", "$CharacterIB", ("run", cls._regValIsOrFix)},
                                         "dress": {"ps-t3", "ResourceRefDressDiffuse", "ResourceRefDressLightMap", "$CharacterIB", ("run", cls._regValIsOrFix)}}),
+                    RegTexEdit(textures = {"HeadShadeLightMap": ["ps-t2"]}),
                     RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1"]},
-                                        "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1"], "ps-t3": ["ps-t2"]}})
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1"], "ps-t3": ["ps-t2"]}})
                 ],
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = {IniKeywords.Ib.value: {"hash": "null"}})], []]})
+                "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
+                "iniPostModelRegEditFilters": [[RegNewVals(vals = {IniKeywords.Ib.value: {"hash": "null"}})], [], []]})
 
     
     @classmethod

--- a/Docs/src/remapGrading.rst
+++ b/Docs/src/remapGrading.rst
@@ -38,8 +38,14 @@ Grading
        |
        | Requires `ORFix`_ to fix up AyakaSpringBloom's reflection
    * - | **AyakaSpringBloom --> Ayaka**
-     - | :greenBold:`4.9`
-     - | 
+     - | :greenBold:`4.8`
+     - | Tried to make AyakaSpringbloom's skin tone to match her face and make her clothes not follow the same shading as her face
+       | by performing the following fix:
+       |
+       | - Change all opaque green colour in the lightmap to become transparent (clothing shading)
+       | - Change all transparent greeen and black colour in the lightmap to become an opaque green colour of rgba(0, 128, 0, 255) (skin tone matching)
+       |
+       | There may be a possibility that we replace more than necessary.
    * - | **Barbara <--> BarbaraSummertime**
      - | :greenBold:`5.0`
      - |
@@ -50,7 +56,7 @@ Grading
        | No easy way to fix this since all the closest vertex groups on HuTao that could be mapped from CherryHuTao's front dress
        | result in the dress clipping her legs when she walks. (unless we start manipulating vertices of the models...)
        |
-       | - We replace pink, yellow, green, blue regions with opacity (alpha) within 65-75 with an opaque green colour of rgb(0, 128, 0, 255) 
+       | - We replace pink, yellow, green, blue regions with opacity (alpha) within 65-75 with an opaque green colour of rgba(0, 128, 0, 255) 
        | to fix HuTao's stockings. There may be a possibility that we replace more than necessary.
    * - | **Diluc --> DilucFlamme**
      - | :greenBold:`4.7`

--- a/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
+++ b/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
@@ -4,7 +4,7 @@ from ..softwareStats.SoftwareContributor import SoftwareContributor
 
 Title = "Anime Game Remap"
 ShortTitle = "AG Remap"
-APIVersion = "4.4.3"
+APIVersion = "4.4.4"
 
 Authors = {
     "Albert": SoftwareContributor("Albert Gold", discName = "albertgold", oldDisName = "Albert Gold#2696"),


### PR DESCRIPTION
- Due to game model changes, Ayaka's body now turns grey after remap. The solution to this fix is to:

1. Map AyakaSpringbloom's head to Ayaka's body
2. Change AyakaSpringbloom's lightmap so that:
   - Opaque green areas are now transparent  (Clothing shading retention to not follow her skin tone)
   - Slightly transparent green and black regions are now opaque green with value of `rgba(0, 128, 0, 255)` (Skin tone matching)

- Also fixed `ColourReplaceFilter` to correctly replace multiple colours or colour ranges