### PR TITLE
Decrease the amount of reflection on Keqing

### DIFF
--- a/Anime Game Remap (for all users)/api/pyproject.toml
+++ b/Anime Game Remap (for all users)/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "4.4.4"
+version = "4.4.5"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
@@ -357,7 +357,11 @@ class IniFixBuilderFuncs():
     
     @classmethod
     def keqingOpulent4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
-        return (GIMIObjSplitFixer, [{"body": ["body", "dress"]}], {})
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {"preRegEditFilters": [
+                    RegTexEdit(textures = {"NonReflectiveLightMap": ["ps-t1"]})
+                ]})
     
     @classmethod
     def kirara4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniParseBuilderData.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniParseBuilderData.py
@@ -350,7 +350,10 @@ class IniParseBuilderFuncs():
     
     @classmethod
     def keqingOpulent4_0(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
-        return (GIMIObjParser, [{"head", "body"}], {})
+        return (GIMIObjParser, 
+                [{"head", "body"}], 
+                {"texEdits": {"head": {"ps-t1": {"NonReflectiveLightMap": TexEditor(filters = [TransparencyAdjustFilter(255, coloursToFilter = {ColourRange(Colour(20, 0, 20, 0), Colour(225, 0, 225, 254)),
+                                                                                                                                                ColourRange(Colour(120, 120, 50, 0), Colour(140, 140, 70, 254))})])}}}})
     
     @classmethod
     def kirara4_0(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/texEditors/texFilters/TransparencyAdjustFilter.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/texEditors/texFilters/TransparencyAdjustFilter.py
@@ -12,12 +12,16 @@
 ##### EndCredits
 
 ##### ExtImports
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Set, Union
 ##### EndExtImports
 
 ##### LocalImports
 from ....textures.Colour import Colour
+from ....textures.ColourRange import ColourRange
 from .BaseTexFilter import BaseTexFilter
+from .....constants.Packages import PackageModules
+from .....constants.GlobalPackageManager import GlobalPackageManager
+from .....constants.ImgFormats import ImgFormats
 
 if (TYPE_CHECKING):
     from ....files.TextureFile import TextureFile
@@ -49,17 +53,76 @@ class TransparencyAdjustFilter(BaseTexFilter):
         .. note::
             The alpha channel for an image is inclusively bounded from 0 to 255
 
+    coloursToFilter: Optional[Set[Union[:class:`Colour`, :class:`ColourRange`]]]
+        The specific colours to have their transparency adjusted. If this value is ``None``, then will adjust the transparency for the entire image`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
     Attributes
     ----------
     alphaChange: :class:`int`
         How much to adjust the alpha channel of each pixel. Range from -255 to 255
     """
 
-    def __init__(self, alphaChange: int):
+    def __init__(self, alphaChange: int, coloursToFilter: Optional[Set[Union[Colour, ColourRange]]] = None):
         self.alphaChange = alphaChange
+        self.coloursToFilter = coloursToFilter
 
-    def transform(self, texFile: "TextureFile"):
+    def adjustTransparency(self, texFile: "TextureFile"):
+        """
+        Adjusts the transparency for the entire image
+
+        Parameters
+        ----------
+        texFile: :class:`TextureFile`
+            The texture to be editted
+        """
+
         alphaImg = texFile.img.getchannel('A')
         alphaImg = alphaImg.point(lambda alphaPixel: Colour.boundColourChannel(alphaPixel + self.alphaChange))
         texFile.img.putalpha(alphaImg)
+
+
+    def transform(self, texFile: "TextureFile"):
+        if (self.coloursToFilter is None):
+            self.adjustTransparency(texFile)
+            return
+        
+        imgSize = texFile.img.size
+        imgBox = (0, 0, imgSize[0], imgSize[1])
+        ImageChops = GlobalPackageManager.get(PackageModules.PIL_ImageChops.value)
+        
+        redImg, greenImg, blueImg, alphaImg = texFile.img.split()
+
+        newAlpha = alphaImg.copy()
+        adjustedAlphaImg = alphaImg.point(lambda alphaPixel: Colour.boundColourChannel(alphaPixel + self.alphaChange))
+
+        i = 0
+        mask = None
+        
+        for colour in self.coloursToFilter:
+            if (isinstance(colour, Colour)):
+                redMatch = redImg.point(lambda redPixel: Colour.boolToColourChannel(redPixel == colour.red)).convert(ImgFormats.Bit.value)
+                greenMatch = greenImg.point(lambda greenPixel: Colour.boolToColourChannel(greenPixel == colour.green)).convert(ImgFormats.Bit.value)
+                blueMatch = blueImg.point(lambda bluePixel: Colour.boolToColourChannel(bluePixel == colour.blue)).convert(ImgFormats.Bit.value)
+                alphaMatch = alphaImg.point(lambda alphaPixel: Colour.boolToColourChannel(alphaPixel == colour.alpha)).convert(ImgFormats.Bit.value)
+            else:
+                redMatch = redImg.point(lambda redPixel: Colour.boolToColourChannel(redPixel >= colour.min.red and redPixel <= colour.max.red)).convert(ImgFormats.Bit.value)
+                greenMatch = greenImg.point(lambda greenPixel: Colour.boolToColourChannel(greenPixel >= colour.min.green and greenPixel <= colour.max.green)).convert(ImgFormats.Bit.value)
+                blueMatch = blueImg.point(lambda bluePixel: Colour.boolToColourChannel(bluePixel >= colour.min.blue and bluePixel <= colour.max.blue)).convert(ImgFormats.Bit.value)
+                alphaMatch = alphaImg.point(lambda alphaPixel: Colour.boolToColourChannel(alphaPixel >= colour.min.alpha and alphaPixel <= colour.max.alpha)).convert(ImgFormats.Bit.value)
+
+            if (i > 0):
+                mask = ImageChops.invert(mask)
+                mask = ImageChops.logical_and(mask, redMatch)
+            else:
+                mask = redMatch
+
+            mask = ImageChops.logical_and(mask, greenMatch)
+            mask = ImageChops.logical_and(mask, blueMatch)
+            mask = ImageChops.logical_and(mask, alphaMatch)
+
+            newAlpha.paste(adjustedAlphaImg, box = imgBox, mask = mask)
+
+        texFile.img.putalpha(newAlpha)
 ##### EndScript

--- a/Anime Game Remap (for all users)/apiMirror/pyproject.toml
+++ b/Anime Game Remap (for all users)/apiMirror/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AnimeGameRemap"
-version = "4.4.4"
+version = "4.4.5"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	"FixRaidenBoss2==4.4.4"
+	"FixRaidenBoss2==4.4.5"
 ]
 
 [project.urls]

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Wednesday, May 28, 2025 08:04:29.477 PM UTC
-# Run Hash: b7b7c87b-3775-4e52-be0f-9591a329156a
+# Datetime Ran: Wednesday, May 28, 2025 11:12:45.126 PM UTC
+# Run Hash: 40c769ce-a78f-4a61-9596-5a893c8fa824
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.4.4
+# Version: 4.4.5
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Wednesday, May 28, 2025 08:04:29.477 PM UTC
-# Build Hash: 58c242a0-f560-4594-8caa-7393ccfdb775
+# Datetime Compiled: Wednesday, May 28, 2025 11:12:45.126 PM UTC
+# Build Hash: 7f162605-a7f5-449e-b4a8-368220f0d61f
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Wednesday, May 28, 2025 08:04:29.477 PM UTC
-# Run Hash: b7b7c87b-3775-4e52-be0f-9591a329156a
+# Datetime Ran: Wednesday, May 28, 2025 11:12:45.126 PM UTC
+# Run Hash: 40c769ce-a78f-4a61-9596-5a893c8fa824
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.4.4
+# Version: 4.4.5
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Wednesday, May 28, 2025 08:04:29.477 PM UTC
-# Build Hash: 58c242a0-f560-4594-8caa-7393ccfdb775
+# Datetime Compiled: Wednesday, May 28, 2025 11:12:45.126 PM UTC
+# Build Hash: 7f162605-a7f5-449e-b4a8-368220f0d61f
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Wednesday, May 28, 2025 08:04:28.294 PM UTC
-# Run Hash: a24da740-7b43-4886-8d36-f54806c66127
+# Datetime Ran: Wednesday, May 28, 2025 11:12:44.2 PM UTC
+# Run Hash: 52df3049-9abe-4675-abf9-b0ac60cff5a9
 # 
 # *******************************
 # ================
@@ -33,10 +33,10 @@
 #
 # ***** AG Remap Script Stats *****
 #
-# Version: 4.4.4
+# Version: 4.4.5
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Wednesday, May 28, 2025 08:04:28.294 PM UTC
-# Build Hash: c4fb4b59-726b-432d-96d8-70b9ebd2f2d9
+# Datetime Compiled: Wednesday, May 28, 2025 11:12:44.2 PM UTC
+# Build Hash: 15cabaf9-24ba-41c1-b409-a408066a0570
 #
 # *********************************
 #
@@ -14565,19 +14565,78 @@ class TransparencyAdjustFilter(BaseTexFilter):
         .. note::
             The alpha channel for an image is inclusively bounded from 0 to 255
 
+    coloursToFilter: Optional[Set[Union[:class:`Colour`, :class:`ColourRange`]]]
+        The specific colours to have their transparency adjusted. If this value is ``None``, then will adjust the transparency for the entire image`<br />` :raw-html:`<br />`
+
+        **Default**: ``None``
+
     Attributes
     ----------
     alphaChange: :class:`int`
         How much to adjust the alpha channel of each pixel. Range from -255 to 255
     """
 
-    def __init__(self, alphaChange: int):
+    def __init__(self, alphaChange: int, coloursToFilter: Optional[Set[Union[Colour, ColourRange]]] = None):
         self.alphaChange = alphaChange
+        self.coloursToFilter = coloursToFilter
 
-    def transform(self, texFile: "TextureFile"):
+    def adjustTransparency(self, texFile: "TextureFile"):
+        """
+        Adjusts the transparency for the entire image
+
+        Parameters
+        ----------
+        texFile: :class:`TextureFile`
+            The texture to be editted
+        """
+
         alphaImg = texFile.img.getchannel('A')
         alphaImg = alphaImg.point(lambda alphaPixel: Colour.boundColourChannel(alphaPixel + self.alphaChange))
         texFile.img.putalpha(alphaImg)
+
+
+    def transform(self, texFile: "TextureFile"):
+        if (self.coloursToFilter is None):
+            self.adjustTransparency(texFile)
+            return
+        
+        imgSize = texFile.img.size
+        imgBox = (0, 0, imgSize[0], imgSize[1])
+        ImageChops = GlobalPackageManager.get(PackageModules.PIL_ImageChops.value)
+        
+        redImg, greenImg, blueImg, alphaImg = texFile.img.split()
+
+        newAlpha = alphaImg.copy()
+        adjustedAlphaImg = alphaImg.point(lambda alphaPixel: Colour.boundColourChannel(alphaPixel + self.alphaChange))
+
+        i = 0
+        mask = None
+        
+        for colour in self.coloursToFilter:
+            if (isinstance(colour, Colour)):
+                redMatch = redImg.point(lambda redPixel: Colour.boolToColourChannel(redPixel == colour.red)).convert(ImgFormats.Bit.value)
+                greenMatch = greenImg.point(lambda greenPixel: Colour.boolToColourChannel(greenPixel == colour.green)).convert(ImgFormats.Bit.value)
+                blueMatch = blueImg.point(lambda bluePixel: Colour.boolToColourChannel(bluePixel == colour.blue)).convert(ImgFormats.Bit.value)
+                alphaMatch = alphaImg.point(lambda alphaPixel: Colour.boolToColourChannel(alphaPixel == colour.alpha)).convert(ImgFormats.Bit.value)
+            else:
+                redMatch = redImg.point(lambda redPixel: Colour.boolToColourChannel(redPixel >= colour.min.red and redPixel <= colour.max.red)).convert(ImgFormats.Bit.value)
+                greenMatch = greenImg.point(lambda greenPixel: Colour.boolToColourChannel(greenPixel >= colour.min.green and greenPixel <= colour.max.green)).convert(ImgFormats.Bit.value)
+                blueMatch = blueImg.point(lambda bluePixel: Colour.boolToColourChannel(bluePixel >= colour.min.blue and bluePixel <= colour.max.blue)).convert(ImgFormats.Bit.value)
+                alphaMatch = alphaImg.point(lambda alphaPixel: Colour.boolToColourChannel(alphaPixel >= colour.min.alpha and alphaPixel <= colour.max.alpha)).convert(ImgFormats.Bit.value)
+
+            if (i > 0):
+                mask = ImageChops.invert(mask)
+                mask = ImageChops.logical_and(mask, redMatch)
+            else:
+                mask = redMatch
+
+            mask = ImageChops.logical_and(mask, greenMatch)
+            mask = ImageChops.logical_and(mask, blueMatch)
+            mask = ImageChops.logical_and(mask, alphaMatch)
+
+            newAlpha.paste(adjustedAlphaImg, box = imgBox, mask = mask)
+
+        texFile.img.putalpha(newAlpha)
 
 
 class TexMetadataFilter(BaseTexFilter):
@@ -15512,7 +15571,10 @@ class IniParseBuilderFuncs():
     
     @classmethod
     def keqingOpulent4_0(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
-        return (GIMIObjParser, [{"head", "body"}], {})
+        return (GIMIObjParser, 
+                [{"head", "body"}], 
+                {"texEdits": {"head": {"ps-t1": {"NonReflectiveLightMap": TexEditor(filters = [TransparencyAdjustFilter(255, coloursToFilter = {ColourRange(Colour(20, 0, 20, 0), Colour(225, 0, 225, 254)),
+                                                                                                                                                ColourRange(Colour(120, 120, 50, 0), Colour(140, 140, 70, 254))})])}}}})
     
     @classmethod
     def kirara4_0(cls) -> Tuple[BaseIniParser, List[Any], Dict[str, Any]]:
@@ -18110,7 +18172,11 @@ class IniFixBuilderFuncs():
     
     @classmethod
     def keqingOpulent4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
-        return (GIMIObjSplitFixer, [{"body": ["body", "dress"]}], {})
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {"preRegEditFilters": [
+                    RegTexEdit(textures = {"NonReflectiveLightMap": ["ps-t1"]})
+                ]})
     
     @classmethod
     def kirara4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:

--- a/Docs/src/remapGrading.rst
+++ b/Docs/src/remapGrading.rst
@@ -118,9 +118,16 @@ Grading
        | - Switching between the character menu screen and the overworld
        | - Switching between Kaeya and KaeyaSailwind
        | - Reloading the mod
-   * - | **Keqing <--> KeqingOpulent**
+   * - | **Keqing --> KeqingOpulent**
      - | :greenBold:`5.0`
      - |
+   * - | **KeqingOpulent --> Keqing**
+     - | :greenBold:`4.8`
+     - | To decrease the amount of reflection in Keqing, we had to the following change:
+       |
+       | - Make all dark purple and dark yellow regions in the ``HeadLightMap.dds`` to be opaque with alpha value 255
+       |
+       | There may be a possibility that we replace more than necessary.
    * - | **Kirara <--> KiraraBoots**
      - | :greenBold:`4.6`
      - | 

--- a/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
+++ b/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
@@ -4,7 +4,7 @@ from ..softwareStats.SoftwareContributor import SoftwareContributor
 
 Title = "Anime Game Remap"
 ShortTitle = "AG Remap"
-APIVersion = "4.4.4"
+APIVersion = "4.4.5"
 
 Authors = {
     "Albert": SoftwareContributor("Albert Gold", discName = "albertgold", oldDisName = "Albert Gold#2696"),


### PR DESCRIPTION
https://github.com/nhok0169/Anime-Game-Remap/issues/172

<br>

- Seems like the remap from `KeqingOpulent` generates to much reflection, especially for her shoes. Lessen the reflection by making all transparent  dark purple and dark yellow regions at KeqingOpulent's `HeadLightMap.dds` to be opaque (alpha value 255)