### PR TITLE
Fix GI 6.1 Diffuse/Lightmap Texture Swap

### DIFF
--- a/Anime Game Remap (for all users)/api/pyproject.toml
+++ b/Anime Game Remap (for all users)/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "4.5.5"
+version = "4.6.0"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
@@ -44,22 +44,30 @@ if (TYPE_CHECKING):
 # IniFixBuilderFunc: Class to define how the IniFixBuilder arguments for some
 #   mod are built for a particular game version
 class IniFixBuilderFuncs():
-    def _regIsTexFxWrapper(val: Tuple[int, str]) -> bool:
+    def _regIsTexFxWrapper(val: Tuple[int, str], part) -> bool:
         return val[1].lower().find(IniKeywords.TexFxFolder.value.lower()) > -1
     
-    def _regValIsOrFixWrapper(val: Tuple[int, str]) -> bool:
+    def _regValIsOrFixWrapper(val: Tuple[int, str], part) -> bool:
         return val[1] == IniKeywords.ORFixPath.value
     
-    def _regValIsNnFixWrapper(val: Tuple[int, str]) -> bool:
+    def _regValIsNnFixWrapper(val: Tuple[int, str], part) -> bool:
         return val[1] == IniKeywords.NNFixPath.value
     
     @classmethod
-    def _regIsTex(cls, val: Tuple[int, str]) -> bool:
+    def _regIsTex(cls, val: Tuple[int, str], part) -> bool:
         return cls._regIsTexFxWrapper(val)
     
     @classmethod
-    def _regValIsOrFix(cls, val: Tuple[int, str]) -> bool:
+    def _regValIsOrFix(cls, val: Tuple[int, str], part) -> bool:
         return cls._regValIsOrFixWrapper(val)
+    
+    @classmethod
+    def _hasNullIb(self, val: Tuple[int, str], part):
+        ibVals = part.get("ib")
+        if (not ibVals):
+            return False
+        
+        return bool(ibVals[-1][1] == "null")
 
     TexFxRemove = {("run", _regIsTexFxWrapper)}
     TexFxTempReg = "tempTexFx"
@@ -72,14 +80,19 @@ class IniFixBuilderFuncs():
     
     ORFixRemove = {("run", _regValIsOrFixWrapper)}
     NNFixRemove = {("run", _regValIsNnFixWrapper)}
-    ReflectionHeadRemove = {"ResourceRefHeadDiffuse", "ResourceRefHeadLightMap", "$CharacterIB", *ORFixRemove}
-    ReflectionBodyRemove = {"ResourceRefBodyDiffuse", "ResourceRefBodyLightMap", "$CharacterIB", *ORFixRemove}
-    ReflectionDressRemove = {"ResourceRefDressDiffuse", "ResourceRefDressLightMap", "$CharacterIB", *ORFixRemove}
-    ReflectionExtraRemove = {"ResourceRefExtraDiffuse", "ResourceRefExtraLightMap", "$CharacterIB", *ORFixRemove}
+    ORFixCompleteRemoval = {*ORFixRemove, *NNFixRemove}
+    ReflectionHeadRemove = {"ResourceRefHeadDiffuse", "ResourceRefHeadLightMap", "$CharacterIB", *ORFixCompleteRemoval}
+    ReflectionBodyRemove = {"ResourceRefBodyDiffuse", "ResourceRefBodyLightMap", "$CharacterIB", *ORFixCompleteRemoval}
+    ReflectionDressRemove = {"ResourceRefDressDiffuse", "ResourceRefDressLightMap", "$CharacterIB", *ORFixCompleteRemoval}
+    ReflectionExtraRemove = {"ResourceRefExtraDiffuse", "ResourceRefExtraLightMap", "$CharacterIB", *ORFixCompleteRemoval}
 
     ORFixTempReg = "tempORFix"
     ORFixValRename = {ORFixTempReg: IniKeywords.ORFixPath.value}
     ORFixTempToRun = {ORFixTempReg: [RemappedKeyData("run", toInd = -1)]}
+
+    NNFixTempReg = "tempNNFix"
+    NNFixValRename = {NNFixTempReg: IniKeywords.NNFixPath.value}
+    NNFixTempToRun = {NNFixTempReg: [RemappedKeyData("run", toInd = -1)]}
 
     DrawIndexedTempReg = "tempDrawIndexed"
     IbRemappedData = RemappedKeyData(DrawIndexedTempReg, toInd = -1)
@@ -125,7 +138,7 @@ class IniFixBuilderFuncs():
         return cls._isShadow(val)
     
     @classmethod
-    def _removeIsNormalMap(cls, val: Tuple[int, str]) -> bool:
+    def _removeIsNormalMap(cls, val: Tuple[int, str], part) -> bool:
         return cls._isNormalMap(val[1])
     
     # =======================================================
@@ -150,6 +163,23 @@ class IniFixBuilderFuncs():
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def amber6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, [],
+                {"postRegEditFilters": [RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                            "body": cls.ORFixCompleteRemoval}),
+                                        RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                          "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                        RegRemap(remap = {"head": cls.IbRemapData,
+                                                          "body": cls.IbRemapData}),
+                                        RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                                           "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                                        RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                                          "body": cls.NNFixTempToRun}),
+                                        RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                                          "body": cls.IbTempToDrawIndexed})],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def amberCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
     
@@ -160,6 +190,23 @@ class IniFixBuilderFuncs():
                                                           "body": cls.IbRemapData}),
                                         RegNewVals(vals = {"head": cls.IbDrawIndexedRename,
                                                            "body": cls.IbDrawIndexedRename}),
+                                        RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                                          "body": cls.IbTempToDrawIndexed})],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+
+    @classmethod
+    def amberCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, [],
+                {"postRegEditFilters": [RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                            "body": cls.ORFixCompleteRemoval}),
+                                        RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                          "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                        RegRemap(remap = {"head": cls.IbRemapData,
+                                                          "body": cls.IbRemapData}),
+                                        RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                                           "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                                        RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                                          "body": cls.NNFixTempToRun}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
@@ -259,6 +306,30 @@ class IniFixBuilderFuncs():
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def ayaka6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                       RegRemove(remove = {"head": {"ps-t2", *cls.ORFixCompleteRemoval},
+                                           "body": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                           "dress": {*cls.ORFixCompleteRemoval}}),
+                       RegTexEdit({"BrightLightMap": ["ps-t1"], "OpaqueDiffuse": ["ps-t0"], "TransparentDiffuse": ["ps-t0"]}),
+                       RegRemap(remap = {"head": {"ps-t1": ["ps-t2", cls.ORFixTempReg], "ps-t0": ["ps-t0", "ps-t1"], **cls.IbRemapData},
+                                         "body": {"ps-t2": ["ps-t3"], "ps-t1": ["ps-t2", cls.ORFixTempReg], "ps-t0": ["ps-t0", "ps-t1"], **cls.IbRemapData},
+                                         "dress": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                       RegTexAdd(textures = {"head": {"ps-t0": ("NormalMap", TexCreator(1024, 1024, colour = Colours.NormalMapPurple1.value))},
+                                             "body": {"ps-t0": ("NormalMap", TexCreator(1024, 1024, colour = Colours.NormalMapPurple1.value))}}, mustAdd = False),
+                       RegNewVals({"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename},
+                                   "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename},
+                                   "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                       RegRemap(remap = {"head": {**cls.ORFixTempToRun, **cls.IbTempToDrawIndexed},
+                                         "body": {**cls.ORFixTempToRun, **cls.IbTempToDrawIndexed},
+                                         "dress": {**cls.NNFixTempToRun, **cls.IbTempToDrawIndexed}})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+
+    @classmethod
     def ayakaSpringbloom4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [], 
@@ -331,7 +402,39 @@ class IniFixBuilderFuncs():
                 "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
-
+    
+    @classmethod
+    def ayakaSpringbloom6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["body", "body"], "body": ["head", "body"], "dress": ["dress", "dress"]}], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t3", *cls.ReflectionHeadRemove},
+                                        "body": {*cls.ReflectionBodyRemove}}),
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t2", (cls.ORFixTempReg, cls._remapIsShadow)], **cls.IbRemapData},
+                                      "body": {"ps-t2": ["ps-t2", (cls.ORFixTempReg, cls._remapIsShadow)], **cls.IbRemapData}}),
+                    RegTexEdit(textures = {"HeadShadeLightMap": [("ps-t2", cls._remapIsShadow)], 
+                                           "HeadAltShadeLightMap": [("ps-t1", cls._remapIsShadow)],
+                                           "BodyTransparentDiffuse": [("ps-t1", cls._remapIsLightMap)],
+                                           "BodyAltTransparentDiffuse": [("ps-t0", cls._remapIsLightMap)],
+                                           "BodyOpaqueGreenLightMap": [("ps-t2", cls._remapIsShadow)],  
+                                           "BodyAltOpaqueGreenLightMap": [("ps-t1", cls._remapIsShadow)]}),
+                    RegNewVals(vals = {"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.ORFixTempToRun},
+                                      "body": {**cls.ORFixTempToRun}}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"dress": {"ps-t3", *cls.ReflectionDressRemove}}),
+                    RegRemap({"dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals({"head": {"ib": "null"}, "dress": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap({"dress": {**cls.NNFixTempToRun}}),
+                    RegRemap({"dress": {**cls.IbTempToDrawIndexed}})
+                ],
+                "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
     
     @classmethod
     def arlecchino5_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -382,6 +485,29 @@ class IniFixBuilderFuncs():
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def barbara6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {"postRegEditFilters": [
+                    RegRemove({"head": cls.ORFixCompleteRemoval,
+                               "body": cls.ORFixCompleteRemoval,
+                               "dress": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                      "body": cls.NNFixTempToRun,
+                                      "dress": cls.NNFixTempToRun}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def barbaraSummertime4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
     
@@ -396,6 +522,29 @@ class IniFixBuilderFuncs():
                     RegNewVals(vals = {"head": cls.IbDrawIndexedRename,
                                        "body": cls.IbDrawIndexedRename,
                                        "dress": cls.IbDrawIndexedRename}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+
+    @classmethod
+    def barbaraSummertime6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {"postRegEditFilters": [
+                   RegRemove({"head": cls.ORFixCompleteRemoval,
+                               "body": cls.ORFixCompleteRemoval,
+                               "dress": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                      "body": cls.NNFixTempToRun,
+                                      "dress": cls.NNFixTempToRun}),
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
@@ -425,6 +574,38 @@ class IniFixBuilderFuncs():
                                            "dress": {**cls.TexFXTempToRun}})
                 ],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value})
+
+    @classmethod
+    def cherryHuTao6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "extra"], "body": ["body", "dress"]}], 
+                {
+                 "preRegEditFilters": [
+                         RegRemove(remove = {"head": {*cls.ReflectionHeadRemove, *cls.TexFxRemove},
+                                             "body": {*cls.ReflectionBodyRemove},
+                                             "dress": {*cls.ReflectionDressRemove, *cls.TexFxRemove},
+                                             "extra": {*cls.ReflectionExtraRemove}}),
+                         RegTexEdit(textures = {"TransparentBodyDiffuse": ["ps-t0"],
+                                                "TransparentyDressDiffuse": ["ps-t1"],
+                                                "OpaqueBodyLightMap": ["ps-t1"]}),
+                         RegRemove(remove = {"head": {"ps-t0"},
+                                             "dress": {"ps-t0"}}),
+                         RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap},
+                                           "dress": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap},
+                                           "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                           "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                         RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0},
+                                            "dress": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0},
+                                            "body": {**cls.NNFixValRename},
+                                            "extra": {**cls.NNFixValRename}}),
+                         RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                           "body": {**cls.NNFixTempToRun},
+                                           "dress": {**cls.NNFixTempToRun},
+                                           "extra": {**cls.NNFixTempToRun}}),
+                         RegRemap(remap = {"head": {**cls.TexFXTempToRun},
+                                           "dress": {**cls.TexFXTempToRun}})
+                ],
+                "copyPreamble": IniComments.GIMIObjMergerPreamble.value})
     
     @classmethod
     def diluc4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -445,6 +626,25 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                 ],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
+    def diluc6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"body": ["body", "dress"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
@@ -477,6 +677,29 @@ class IniFixBuilderFuncs():
                  "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
     
     @classmethod
+    def dilucFlamme6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegTexEdit({"TransparentBodyDiffuse": ["ps-t0"], "TransparentDressDiffuse": ["ps-t0"]})
+                 ],
+                 "postRegEditFilters":  [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
+                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+    
+    @classmethod
     def fischl4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjMergeFixer, 
                 [{"body": ["body", "dress"]}], 
@@ -498,7 +721,26 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed})
                  ],
                  "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
-
+    
+    @classmethod
+    def fischl6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                 "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
+                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
     
     @classmethod
     def fischlHighness4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -530,7 +772,31 @@ class IniFixBuilderFuncs():
                     RegNewVals({"dress": {"ib": "null"}})
                 ],
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
-
+    
+    @classmethod
+    def fischlHighness6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"body": ["body", "dress"]}], 
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
+                 "postRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}}),
+                    RegNewVals({"dress": {"ib": "null"}})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
     def ganyu4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -570,6 +836,33 @@ class IniFixBuilderFuncs():
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def ganyu6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.TexFxRemove, *cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2", cls.ORFixTempReg], **cls.TexFxTempRegRemap, **cls.IbRemapData},
+                                      "body": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegTexEdit(textures = {"DarkDiffuse": ["ps-t1"]}),
+                    RegTexAdd(textures = {"head": {"ps-t0": ("NormalMap", TexCreator(1024, 1024, colour = Colours.NormalMapYellow.value))}}),
+                    RegNewVals(vals = {"head": {**cls.ORFixValRename, **cls.TexFXToNormalValRename5_0, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.ORFixTempToRun,
+                                      "body": cls.NNFixTempToRun,
+                                      "dress": cls.NNFixTempToRun}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def ganyuTwilight4_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [], 
@@ -599,6 +892,31 @@ class IniFixBuilderFuncs():
                                        "body": cls.IbDrawIndexedRename,
                                        "dress": cls.IbDrawIndexedRename}),
                     RegRemap(remap = {"head": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
+    def ganyuTwilight6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t0", *cls.ReflectionHeadRemove, *cls.TexFxRemove},
+                                        "body": {*cls.ReflectionBodyRemove},
+                                        "dress": {*cls.ReflectionDressRemove}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap, **cls.IbRemapData},
+                                      "body": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.TexFxNoNormalValRename5_0, **cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}}),
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
@@ -664,6 +982,39 @@ class IniFixBuilderFuncs():
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def hutao6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head", "extra"], "body": ["body", "dress"]}],
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"},
+                                        "body": {"ps-t2", "ps-t3"}}),
+                    RegRemap(remap = {"head": cls.IbRemapData,
+                                      "body": cls.IbRemapData}),
+                    RegNewVals(vals = {"head": cls.IbDrawIndexedRename,
+                                       "body": cls.IbDrawIndexedRename}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.TexFxRemove},
+                                        "dress": {*cls.TexFxRemove},
+                                        "extra": {"ps-t0", "ps-t1"}}),
+                    RegNewVals(vals = {"extra": {IniKeywords.Ib.value: "null"}, 
+                                       "dress": {IniKeywords.Ib.value: "null"}}),
+                    RegTexEdit(textures = {"TransparentHeadDiffuse": ["ps-t0"]}),
+                    RegRemap(remap = {"head": {"ps-t0": ["ps-t0", "ps-t2"], **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2"], **cls.TexFxTempRegRemap}}),
+                    RegNewVals(vals = {"head": {"ps-t0": "null", **cls.TexFXToNormalValRename5_0},
+                                       "dress": {**cls.TexFXToNormalValRename5_0}}),
+                    RegTexAdd(textures = {"dress": {"ps-t0": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapBlue.value))}}, mustAdd = False),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun},
+                                      "dress": {**cls.TexFXTempToRun}})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def jean4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (MultiModFixer, 
                 [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer), 
@@ -676,11 +1027,12 @@ class IniFixBuilderFuncs():
                 [{ModTypeNames.Jean.value: IniFixBuilder(GIMIObjRegEditFixer), 
                   ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, args = [{"body": ["body", "dress"]}])}],
                 {})
-    
+
     @classmethod
     def jean5_5(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (MultiModFixer, 
-                [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer, kwargs = {}), 
+                [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer, 
+                                                           kwargs = {}), 
                   ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, 
                                                             args = [{"body": ["body", "dress"]}],
                                                             kwargs = {
@@ -693,13 +1045,81 @@ class IniFixBuilderFuncs():
                 {})
     
     @classmethod
+    def jean6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (MultiModFixer, 
+                [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer, 
+                                                           kwargs = {"preRegEditFilters": [
+                                                                RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                    "body": cls.ORFixCompleteRemoval}),
+                                                                RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                "body": {**cls.NNFixValRename}}),
+                                                                RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                "body": {**cls.NNFixTempToRun}})
+                                                           ]}), 
+                  ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, args = [{"body": ["body", "dress"]}],
+                                                            kwargs = {
+                                                                "preRegEditOldObj": True,
+                                                                "preRegEditFilters": [
+                                                                RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                    "body": cls.ORFixCompleteRemoval}),
+                                                                RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                "body": {**cls.NNFixValRename}}),
+                                                                RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                "body": {**cls.NNFixTempToRun}}),
+                                                            ],
+                                                            "postRegEditFilters": [
+                                                                    RegNewVals(vals = {"dress": {"ib": "null"}}),
+                                                                    RegTexEdit(textures = {"ShadeLightMap": ["ps-t1"]})
+                                                            ]})}],
+                {})
+    
+    @classmethod
     def jeanCN5_5(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (MultiModFixer, 
                 [{ModTypeNames.Jean.value: IniFixBuilder(GIMIObjRegEditFixer, kwargs = {}), 
                   ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, 
-                                                            args = [{"body": ["body", "dress"]}],
+                                                            args = [{"head": ["head"], "body": ["body", "dress"]}],
                                                             kwargs = {
                                                                 
+                                                                "postRegEditFilters": [
+                                                                    RegNewVals(vals = {"dress": {"ib": "null"}}),
+                                                                    RegTexEdit(textures = {"ShadeLightMap": ["ps-t1"]})
+                                                                ]
+                                                            })}],
+                {})
+    
+    @classmethod
+    def jeanCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (MultiModFixer, 
+                [{ModTypeNames.Jean.value: IniFixBuilder(GIMIObjRegEditFixer, 
+                                                         kwargs = {"preRegEditFilters": [
+                                                                RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                    "body": cls.ORFixCompleteRemoval}),
+                                                                RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                "body": {**cls.NNFixValRename}}),
+                                                                RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                "body": {**cls.NNFixTempToRun}})
+                                                           ]}), 
+                  ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, 
+                                                            args = [{"head": ["head"], "body": ["body", "dress"]}],
+                                                            kwargs = {
+                                                                "preRegEditOldObj": True,
+                                                                "preRegEditFilters": [
+                                                                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                        "body": cls.ORFixCompleteRemoval}),
+                                                                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                    "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                    "body": {**cls.NNFixValRename}}),
+                                                                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                    "body": {**cls.NNFixTempToRun}}),
+                                                                ],
                                                                 "postRegEditFilters": [
                                                                     RegNewVals(vals = {"dress": {"ib": "null"}}),
                                                                     RegTexEdit(textures = {"ShadeLightMap": ["ps-t1"]})
@@ -713,6 +1133,23 @@ class IniFixBuilderFuncs():
                 [{"body": ["body", "dress"]}], 
                 {
                  "copyPreamble": IniComments.GIMIObjMergerPreamble.value})
+
+    @classmethod
+    def jeanSea6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                    "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                    "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                    "body": {**cls.NNFixTempToRun}}),
+                    ]})
     
     @classmethod
     def kaeya4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -738,6 +1175,27 @@ class IniFixBuilderFuncs():
                     RegNewVals(vals = {"body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFXToNormalValRename5_0}}),
                     RegRemap(remap = {"body": {**cls.TexFXTempToRun}}),
                     RegRemap(remap = {"body": cls.ORFixTempToRun})
+                ]})
+    
+    @classmethod
+    def kaeya6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {"postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.TexFxRemove, *cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2", cls.ORFixTempReg], "ps-t2": ["ps-t3"], **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegTexAdd(textures = {"body": {"ps-t0": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapYellow.value))}}, mustAdd = False),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFXToNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"body": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                      "body": cls.ORFixTempToRun,
+                                      "dress": cls.NNFixTempToRun})
                 ]})
     
     @classmethod
@@ -767,12 +1225,53 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def kaeyaSailwind6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer,
+                [{"head": ["head"], "body": ["body"], "dress": ["dress", "extra"]}],
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ReflectionHeadRemove},
+                                        "body": {*cls.ReflectionBodyRemove, *cls.TexFxRemove},
+                                        "dress": {*cls.ReflectionDressRemove}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], "ps-t3": ["ps-t2"], **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"body": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def keqing4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjMergeFixer, 
                 [{"head": ["dress", "head"]}], 
                 {
-                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, "preRegEditFilters": [
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
                     RegTexEdit({"OpaqueDressDiffuse": ["ps-t0"], "OpaqueHeadDiffuse": ["ps-t0"]})
+                ]})
+    
+    @classmethod
+    def keqing6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["dress", "head"], "body": ["body"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegTexEdit({"OpaqueDressDiffuse": ["ps-t0"], "OpaqueHeadDiffuse": ["ps-t0"]})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -781,6 +1280,25 @@ class IniFixBuilderFuncs():
                 [{"head": ["head"], "body": ["body", "dress"]}], 
                 {"preRegEditFilters": [
                     RegTexEdit(textures = {"NonReflectiveLightMap": ["ps-t1"]})
+                ]})
+    
+    @classmethod
+    def keqingOpulent6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ],
+                 "postRegEditFilters": [
+                    RegTexEdit(textures = {"NonReflectiveLightMap": ["ps-t1"]}),
                 ]})
     
     @classmethod
@@ -821,6 +1339,33 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def kirara6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [],
+                {
+                    "preRegEditFilters": [
+                    RegRemove(remove = {
+                        "head": {*cls.ReflectionHeadRemove, *cls.TexFxRemove}, 
+                        "body": {*cls.ReflectionBodyRemove, *cls.TexFxRemove}, 
+                        "dress": {*cls.ReflectionDressRemove, *cls.TexFxRemove}}),
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t2", cls.ORFixTempReg], **cls.TexFxTempRegRemap},
+                                      "body": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True), 
+                                               **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": KeyRemapData.build([("ps-t0", cls._remapIsDiffuse), cls.NNFixTempReg], keepKeyWithoutRemap = True), 
+                                                "ps-t2": KeyRemapData.build([("ps-t1", cls._remapIsLightMap)], keepKeyWithoutRemap = True), 
+                                                **cls.TexFxTempRegRemap}}),
+                    RegNewVals(vals = {"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun},
+                                      "body": {**cls.TexFXTempToRun},
+                                      "dress": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.ORFixTempToRun,
+                                      "body": cls.ORFixTempToRun,
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def kiraraBoots4_8(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [], 
@@ -855,6 +1400,33 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def kiraraBoots6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ReflectionHeadRemove, *cls.TexFxRemove},
+                                        "body": {*cls.ReflectionBodyRemove, *cls.TexFxRemove},
+                                        "dress": {*cls.ORFixCompleteRemoval, "ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t0": KeyRemapData.build([("tempNorm", cls._remapIsDiffuse), ("ps-t1", cls._remapIsDiffuse)], keepKeyWithoutRemap = True), 
+                                               "ps-t1": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True), 
+                                               "ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True),
+                                               **cls.TexFxTempRegRemap},
+                                      "body": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True),
+                                               **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegTexAdd(textures = {"head": {"tempNorm": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapYellow.value))}}, mustAdd = False),
+                    RegNewVals(vals = {"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {"tempNorm": ["ps-t0"], **cls.TexFXTempToRun},
+                                      "body": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.ORFixTempToRun,
+                                      "body": cls.ORFixTempToRun,
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def klee4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer, 
                 [{"body": ["body", "dress"]}], 
@@ -862,6 +1434,24 @@ class IniFixBuilderFuncs():
                  "preRegEditFilters": [
                     RegTexEdit(textures = {"GreenLightMap": ["ps-t1"]}),
                     RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}})
+                ]})
+
+    @classmethod
+    def klee6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegTexEdit(textures = {"GreenLightMap": ["ps-t1"]}),
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}}),
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -873,6 +1463,28 @@ class IniFixBuilderFuncs():
                     RegTexEdit(textures = {"TransparentDiffuse": ["ps-t0"]}),
                     RegRemove(remove = {"head": {"ps-t2"}}),
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
+                ]})
+    
+    @classmethod
+    def kleeBlossomingStarlight6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegTexEdit(textures = {"TransparentDiffuse": ["ps-t0"]}),
+                    RegRemove(remove = {"head": {"ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -933,6 +1545,28 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def lisa6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer,
+                [{"head": ["head"], "body": ["body", "dress"]}],
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"},
+                                        "body": {"ps-t3"},
+                                        "dress": {"ps-t2"}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def lisaStudent4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer,
                 [{"body": ["body", "dress"]}],
@@ -953,12 +1587,62 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def lisaStudent6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer,
+                [{"body": ["body", "dress"]}],
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t0", "ps-t3", *cls.TexFxRemove, *cls.ORFixCompleteRemoval}, 
+                                        "body": {"ps-t0", "ps-t3", *cls.TexFxRemove, *cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap},
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap}}),
+                    RegNewVals(vals = {"head": {**cls.TexFxNoNormalValRename4_0, **cls.NNFixValRename},
+                                       "body": {**cls.TexFxNoNormalValRename4_0, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun, **cls.NNFixTempToRun},
+                                      "body": {**cls.TexFXTempToRun, **cls.NNFixTempToRun}})
+                ],
+                "postRegEditFilters": [
+                    RegRemap(remap = {"body": {"ps-t3": ["ps-t2"]}})
+                ]})
+    
+    @classmethod
     def mona4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
     
     @classmethod
+    def mona6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def monaCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
+    
+    @classmethod
+    def monaCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
     
     @classmethod
     def nilou4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -989,9 +1673,9 @@ class IniFixBuilderFuncs():
                 [], 
                 {
                  "preRegEditFilters": [
-                    RegRemove(remove = {"head": {("ps-t0", cls._removeIsNormalMap), cls.ReflectionHeadRemove}, 
-                                        "body": {("ps-t0", cls._removeIsNormalMap), cls.ReflectionDressRemove}, 
-                                        "dress": {("ps-t0", cls._removeIsNormalMap), cls.ReflectionDressRemoves}}),
+                    RegRemove(remove = {"head": {("ps-t0", cls._removeIsNormalMap), *cls.ReflectionHeadRemove}, 
+                                        "body": {("ps-t0", cls._removeIsNormalMap), *cls.ReflectionBodyRemove}, 
+                                        "dress": {("ps-t0", cls._removeIsNormalMap), *cls.ReflectionDressRemove}}),
                     RegRemap(remap = {"head": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True)},
                                         "body": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True)},
                                         "dress": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True)}}),
@@ -1067,6 +1751,26 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def nilouBreeze6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "dress": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "body": {"ps-t3", *cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def ningguang4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [],
@@ -1076,8 +1780,48 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def ningguang6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [],
+                {
+                 "preRegEditFilters": [
+                    RegTexEdit({"DarkDiffuse": ["ps-t0"]}),
+                    RegRemove(remove = {"head": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "dress": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "body": {"ps-t3", *cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def ningguangOrchid4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
+    
+    @classmethod
+    def ningguangOrchid6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
     
     @classmethod
     def isRaidenBody(cls, ini, line, pattern):
@@ -1097,11 +1841,12 @@ class IniFixBuilderFuncs():
     @classmethod
     def raiden6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer, 
-                [{"body": ["body", "bodydiffuse", "bodylightmap"],
+                [{"body": ["body", "bodydiffuse", "bodylightmap", "bodyreflection"],
                   "dress": ["dress", "dressdiffuse", "dresslightmap"]}], 
                 {
                  "preRegEditOldObj": True,
                  "postIniProcessor": cls.raidenHideOrigBody,
+                 "nameReplace": {"bodyreflection": lambda oldName: oldName.replace("TextureOverride", "ShaderOverride")},
                  "preRegEditFilters": [
                      RegRemove(remove = {"head": {*cls.NNFixRemove},
                                          "body": {*cls.NNFixRemove},
@@ -1109,20 +1854,31 @@ class IniFixBuilderFuncs():
                  ],
                  "postRegEditFilters": [
                     RegRemove(remove = {"body": {"ps-t0", "ps-t1", "ps-t2"},
-                                        "bodydiffuse": {"ps-t1", "ps-t2", "ib", "match_first_index"},
-                                        "bodylightmap": {"ps-t0", "ps-t2", "ib", "match_first_index"},
+                                        "bodydiffuse": {"ps-t1", "ps-t2"},
+                                        "bodylightmap": {"ps-t0", "ps-t2"},
                                         "dress": {"ps-t0", "ps-t1", "ps-t2"},
-                                        "dressdiffuse": {"ps-t1", "ps-t2", "ib", "match_first_index"},
-                                        "dresslightmap": {"ps-t0", "ps-t2", "ib", "match_first_index"}}),
-                    RegNewVals(vals = {"bodydiffuse": {"hash": "9b5d87e0"},
-                                       "dressdiffuse": {"hash": "9b5d87e0"},
-                                       "bodylightmap": {"hash": "452e0279"},
-                                       "dresslightmap": {"hash": "452e0279"}}),
+                                        "dressdiffuse": {"ps-t1", "ps-t2"},
+                                        "dresslightmap": {"ps-t0", "ps-t2"},}),
+                    RegNewVals(vals = {"bodydiffuse": {"hash": "9b5d87e0", "match_first_index": "17769"},
+                                       "dressdiffuse": {"hash": "9b5d87e0", "match_first_index": "52473"},
+                                       "bodylightmap": {"hash": "452e0279", "match_first_index": "17769"},
+                                       "dresslightmap": {"hash": "452e0279", "match_first_index": "52473"},
+                                       "bodyreflection": {"hash": "693d8ed0af54876d"}}),
                     RegRemap({"head": {"ps-t1": ["ps-t1", "temp"]},
                               "bodydiffuse": {"ps-t0": ["this"]},
                               "bodylightmap": {"ps-t1": ["this"]},
                               "dressdiffuse": {"ps-t0": ["this"]},
                               "dresslightmap": {"ps-t1": ["this"]}}),
+                    RegRemove(remove = {"bodydiffuse": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "bodylightmap": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "bodyreflection": {("hash", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "dressdiffuse": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "dresslightmap": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)}}),
+                    RegRemove(remove = {"bodydiffuse": {"ib"},
+                                        "bodylightmap": {"ib"},
+                                        "dressdiffuse": {"ib"},
+                                        "dresslightmap": {"ib"},
+                                        "bodyreflection": {"ib", "match_first_index"}}),
                     RegNewVals({"head": {"temp": IniKeywords.NNFixPath.value}}),
                     RegRemap({"head": {"temp": ["run"]}})
                 ]})
@@ -1132,8 +1888,54 @@ class IniFixBuilderFuncs():
         return (GIMIObjRegEditFixer, [], {})
     
     @classmethod
+    def rosaria6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "extra": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename},
+                                       "extra": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun},
+                                      "extra": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def rosariaCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
+    
+    @classmethod
+    def rosariaCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "extra": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename},
+                                       "extra": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun},
+                                      "extra": {**cls.NNFixTempToRun}})
+                ]})
     
     @classmethod
     def shenhe4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -1143,6 +1945,34 @@ class IniFixBuilderFuncs():
                  "preRegEditFilters": [
                     RegRemove(remove = {"dress": ["ps-t2"]}),
                     RegRemap(remap = {"dress": {"ps-t3": ["ps-t2"]}})
+                ]})
+    
+    @classmethod
+    def shenhe6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body"], "dress": ["dress", "extra"]}], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"dress": ["ps-t2"]}),
+                    RegRemap(remap = {"dress": {"ps-t3": ["ps-t2"]}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "extra": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename},
+                                       "extra": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun},
+                                      "extra": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -1160,6 +1990,28 @@ class IniFixBuilderFuncs():
                  "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
                  "postRegEditFilters": [
                      RegNewVals(vals = {"head": {"ib": "null"}})
+                 ]})
+    
+    @classmethod
+    def shenheFrostFlower6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head", "head"], "body": ["head", "body", "extra"], "dress": ["dress", "dress", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                 "postRegEditFilters": [
+                     RegNewVals(vals = {"head": {"ib": "null"}}),
+                     RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval,
+                                        "dress": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
                  ]})
     
     @classmethod
@@ -1204,10 +2056,49 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def xianglingCheer6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer,
+                [{"head": ["head", "dress"], "body": ["body"]}], 
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t0", *cls.ReflectionHeadRemove}, 
+                                        "body": {"ps-t0", *cls.ReflectionBodyRemove}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ],
+                "postRegEditFilters": [
+                    RegNewVals(vals = {"head": {IniKeywords.Ib.value: "null"}})
+                ]})
+    
+    @classmethod
     def xingqiu4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer, 
                 [{"head": ["head", "dress"]}], 
                 {
+                 "postRegEditFilters": [
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}})
+                ]})
+    
+    @classmethod
+    def xingqiu6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head", "dress"], "body": ["body"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval}, 
+                                        "body": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ],
                  "postRegEditFilters": [
                     RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}})
                 ]})
@@ -1222,7 +2113,27 @@ class IniFixBuilderFuncs():
                     RegRemove(remove = {"head": {"ps-t2"}}),
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
                 ]})
-
+    
+    @classmethod
+    def xingqiuBamboo6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "dress"], "body": ["body", "body"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval}, 
+                                        "body": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
 
 IniFixBuilderData = {
     4.0: {
@@ -1326,6 +2237,47 @@ IniFixBuilderData = {
         ModTypeNames.ShenheFrostFlower.value: IniFixBuilderFuncs.shenheFrostFlower5_7
     },
 
-    6.1: {ModTypeNames.Raiden.value: IniFixBuilderFuncs.raiden6_1}
+    6.1: {
+        ModTypeNames.Amber.value: IniFixBuilderFuncs.amber6_1,
+        ModTypeNames.AmberCN.value: IniFixBuilderFuncs.amberCN6_1,
+        ModTypeNames.Ayaka.value: IniFixBuilderFuncs.ayaka6_1,
+        ModTypeNames.AyakaSpringbloom.value: IniFixBuilderFuncs.ayakaSpringbloom6_1,
+        ModTypeNames.Barbara.value: IniFixBuilderFuncs.barbara6_1,
+        ModTypeNames.BarbaraSummertime.value: IniFixBuilderFuncs.barbaraSummertime6_1,
+        ModTypeNames.CherryHuTao.value: IniFixBuilderFuncs.cherryHuTao6_1,
+        ModTypeNames.Diluc.value: IniFixBuilderFuncs.diluc6_1,
+        ModTypeNames.DilucFlamme.value: IniFixBuilderFuncs.dilucFlamme6_1,
+        ModTypeNames.Fischl.value: IniFixBuilderFuncs.fischl6_1,
+        ModTypeNames.FischlHighness.value: IniFixBuilderFuncs.fischlHighness6_1,
+        ModTypeNames.GanyuTwilight.value: IniFixBuilderFuncs.ganyuTwilight6_1,
+        ModTypeNames.Ganyu.value: IniFixBuilderFuncs.ganyu6_1,
+        ModTypeNames.HuTao.value: IniFixBuilderFuncs.hutao6_1,
+        ModTypeNames.Jean.value: IniFixBuilderFuncs.jean6_1,
+        ModTypeNames.JeanCN.value: IniFixBuilderFuncs.jeanCN6_1,
+        ModTypeNames.JeanSea.value: IniFixBuilderFuncs.jeanSea6_1,
+        ModTypeNames.KaeyaSailwind.value: IniFixBuilderFuncs.kaeyaSailwind6_1,
+        ModTypeNames.Kaeya.value: IniFixBuilderFuncs.kaeya6_1,
+        ModTypeNames.Keqing.value: IniFixBuilderFuncs.keqing6_1,
+        ModTypeNames.KeqingOpulent.value: IniFixBuilderFuncs.keqingOpulent6_1,
+        ModTypeNames.KiraraBoots.value: IniFixBuilderFuncs.kiraraBoots6_1,
+        ModTypeNames.Kirara.value: IniFixBuilderFuncs.kirara6_1,
+        ModTypeNames.Klee.value: IniFixBuilderFuncs.klee6_1,
+        ModTypeNames.KleeBlossomingStarlight.value: IniFixBuilderFuncs.kleeBlossomingStarlight6_1,
+        ModTypeNames.Lisa.value: IniFixBuilderFuncs.lisa6_1,
+        ModTypeNames.LisaStudent.value: IniFixBuilderFuncs.lisaStudent6_1,
+        ModTypeNames.Mona.value: IniFixBuilderFuncs.mona6_1,
+        ModTypeNames.MonaCN.value: IniFixBuilderFuncs.monaCN6_1,
+        ModTypeNames.NilouBreeze.value: IniFixBuilderFuncs.nilouBreeze6_1,
+        ModTypeNames.Ningguang.value: IniFixBuilderFuncs.ningguang6_1,
+        ModTypeNames.NingguangOrchid.value: IniFixBuilderFuncs.ningguangOrchid6_1,
+        ModTypeNames.Rosaria.value: IniFixBuilderFuncs.rosaria6_1,
+        ModTypeNames.RosariaCN.value: IniFixBuilderFuncs.rosariaCN6_1,
+        ModTypeNames.Shenhe.value: IniFixBuilderFuncs.shenhe6_1,
+        ModTypeNames.ShenheFrostFlower.value: IniFixBuilderFuncs.shenheFrostFlower6_1,
+        ModTypeNames.XianglingCheer.value: IniFixBuilderFuncs.xianglingCheer6_1,
+        ModTypeNames.Xingqiu.value: IniFixBuilderFuncs.xingqiu6_1,
+        ModTypeNames.XingqiuBamboo.value: IniFixBuilderFuncs.xingqiuBamboo6_1,
+        ModTypeNames.Raiden.value: IniFixBuilderFuncs.raiden6_1
+    }
 }
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/iftemplate/IfContentPart.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/iftemplate/IfContentPart.py
@@ -14,6 +14,7 @@
 
 ##### ExtImports
 import copy
+import itertools as IT
 from collections import defaultdict
 from typing import List, Dict, Tuple, Union, Set, Union, Callable, Any, Optional
 ##### EndExtImports
@@ -343,7 +344,10 @@ class IfContentPart(IfTemplatePart):
     
     @src.setter
     def src(self, newSrc: Dict[str, List[Tuple[int, str]]]):
-        self._src = newSrc
+        self._src = copy.copy(newSrc)
+        for key in self._src:
+            self._src[key] = sorted(self._src[key], key = lambda data: data[0])
+
         self._setupOrder()
 
     def _setupOrder(self):
@@ -420,7 +424,7 @@ class IfContentPart(IfTemplatePart):
         keyData = self._order[orderInd]
         self._order[orderInd] = (keyData[0], newInd)
     
-    def removeKey(self, key: Union[str, Tuple[str, Callable[[Tuple[int, str]], bool]]]):
+    def removeKey(self, key: Union[str, Tuple[str, Callable[[Tuple[int, str], "IfContentPart"], bool]]]):
         """
         Removes a key from the part.
 
@@ -439,7 +443,7 @@ class IfContentPart(IfTemplatePart):
 
         orderIndsToRemove = set()
         values = None
-        pred = lambda val: True
+        pred = lambda val, part: True
         targetKey = key
 
         if (isinstance(key, tuple) and len(key) >= 2):
@@ -456,7 +460,7 @@ class IfContentPart(IfTemplatePart):
 
         for i in range(valuesLen):
             value = values[i]
-            if (pred(value)):
+            if (pred(value, self)):
                 orderIndsToRemove.add(value[0])
                 currentValRemovedInds.add(i)
 
@@ -480,7 +484,7 @@ class IfContentPart(IfTemplatePart):
             valData = self.src[orderData[0]][orderData[1]]
             self.src[orderData[0]][orderData[1]] = (i, valData[1])
 
-    def removeKeys(self, keys: Set[Union[str, Tuple[str, Callable[[Tuple[int, str]], bool]]]]):
+    def removeKeys(self, keys: Set[Union[str, Tuple[str, Callable[[Tuple[int, str], "IfContentPart"], bool]]]]):
         """
         Removes multiple keys from the part
 
@@ -500,7 +504,7 @@ class IfContentPart(IfTemplatePart):
         orderIndsToRemove = set()
 
         for key in keys:
-            pred = lambda val: True
+            pred = lambda val, part: True
             targetKey = key
 
             if (isinstance(key, tuple) and len(key) >= 2):
@@ -518,7 +522,7 @@ class IfContentPart(IfTemplatePart):
 
             for i in range(valuesLen):
                 value = values[i]
-                if (pred(value)):
+                if (pred(value, self)):
                     orderIndsToRemove.add(value[0])
                     currentValRemovedInds.add(i)
 
@@ -687,6 +691,63 @@ class IfContentPart(IfTemplatePart):
                 valData = self.src[key][i]
                 self.src[key][i] = (valData[0], vals[i])
 
+    def reorder(self, orderMap: Dict[int, int]):
+        """
+        Reorders the `KVPs`_
+
+        Parameters
+        ----------
+        orderMap: Dict[:class:`int`, :class:`int`]
+            The mapping of how to reorder the `KVPs`_ :raw-html:`<br />` :raw-html:`<br />`
+
+            The keys are the original indices of the `KVPs`_ and the values are the new indices for the `KVPs`_
+        """
+
+        newOrder = []
+        orderLen = len(self._order)
+
+        for i in range(orderLen + 1):
+            currentOrderPart = deque()
+            if (i < orderLen and i not in orderMap):
+                currentOrderPart.append(self._order[i])
+
+            newOrder.append(currentOrderPart)
+
+        # move the kvps
+        for fromInd in orderMap:
+            toInd = orderMap[fromInd]
+            keyData = self._order[fromInd]
+
+            if (toInd > orderLen):
+                toInd = orderLen
+            elif (-orderLen - 1 < toInd < 0):
+                toInd = orderLen + 1 + toInd
+            elif (toInd <= -orderLen - 1):
+                toInd = 0
+
+            newOrder[toInd].append(keyData)
+
+        # update the src
+        newOrder = list(IT.chain(*newOrder))
+        orderLen = len(newOrder)
+
+        for i in range(orderLen):
+            key, occurence = newOrder[i]
+            _, val = self._src[key][occurence]
+            self._src[key][occurence] = (i, val)
+        
+        # update the ordering
+        for key in self._src:
+            keyValData = self._src[key]
+            keyValData.sort(key = lambda valData: valData[0])
+            keyValDataLen = len(keyValData)
+
+            for i in range(keyValDataLen):
+                orderInd, val = keyValData[i]
+                newOrder[orderInd] = (key, i)
+
+        self._order = newOrder
+
     def remapKeys(self, keyRemap: Dict[str, Union[KeyRemapData, List[Union[str, Tuple[str, Callable[[str, str], bool]], RemappedKeyData]]]]):
         """
         Remaps the keys in the `KVP`_s of the parts
@@ -707,7 +768,6 @@ class IfContentPart(IfTemplatePart):
                     * A class that contains all the necessary information for remapping to the new key
         """
 
-        occurences = defaultdict(lambda: 0)
         i = 0
         orderLen = len(self._order)
         keysToRemove = set()
@@ -715,10 +775,8 @@ class IfContentPart(IfTemplatePart):
         convertedKeyRemap = {}
 
         newOrder = []
-        orderNewOccurences = []
-        for i in range(orderLen):
+        for i in range((orderLen + 1) * 2):
             newOrder.append([])
-            orderNewOccurences.append(-1)
 
         newSrc = defaultdict(lambda: [])
         for key in self._src:
@@ -727,21 +785,16 @@ class IfContentPart(IfTemplatePart):
         for i in range(orderLen):
             keyData = self._order[i]
             key = keyData[0]
-            keyOccurence = keyData[1]
-            currentMaxOccurence = occurences[key]
-            
-            # update the occurence of the key
-            if (keyOccurence < currentMaxOccurence):
-                self._order[i] = (key, currentMaxOccurence)
-                orderNewOccurences[i] = currentMaxOccurence
+            fromKeyOccurence = keyData[1]
+            newFromKeyOccurence = len(newSrc[key])
 
-            keyValData = self.src[key][keyOccurence]
+            keyValData = self.src[key][fromKeyOccurence]
             keyVal = keyValData[1]
 
             inKeyRemap = key in keyRemap
             if (not inKeyRemap):
-                occurences[key] += 1
-                newSrc[key].append((i, keyVal))
+                newSrc[key].append((-1, keyVal))
+                newOrder[i * 2].append((key, newFromKeyOccurence))
                 continue
 
             newKeys = keyRemap[key]
@@ -764,21 +817,34 @@ class IfContentPart(IfTemplatePart):
                 if (check is not None and not check(key, keyVal)):
                     continue
 
+                toKeyOccurence = len(newSrc[newKey])
+
                 if (not keyRemapped):
                     keyRemapped = True
 
-                if (toInd is None):
+                hasToInd = toInd is not None
+                if (not hasToInd):
                     toInd = i
 
-                newOrder[toInd].append((newKey, occurences[newKey]))
+                if (toInd >= orderLen):
+                    toInd = orderLen
+                elif (-orderLen - 1 < toInd < 0):
+                    toInd = orderLen + 1 + toInd
+                elif (toInd <= -orderLen - 1):
+                    toInd = 0
+
+                toInd *= 2
+                if (hasToInd):
+                    toInd += 1
+
+                newOrder[toInd].append((newKey, toKeyOccurence))
                 newSrc[newKey].append((-1, keyVal))
 
                 keysToAdd.add(newKey)
-                occurences[newKey] += 1
 
             if (not keyRemapped and keepKeyWithoutRemap):
-                occurences[key] += 1
-                newSrc[key].append((i, keyVal))
+                newSrc[key].append((-1, keyVal))
+                newOrder[i * 2].append((key, newFromKeyOccurence))
 
             if (not keepKeyWithoutRemap or (keyRemapped and keepKeyWithoutRemap)):
                 keysToRemove.add(key)
@@ -788,28 +854,26 @@ class IfContentPart(IfTemplatePart):
             if (key not in keysToAdd):
                 del newSrc[key]
 
-        # construct the new order
-        for i in range(orderLen):
-            keyData = self._order[i]
-            key = keyData[0]
-
-            if (key not in keysToRemove):
-                newOrder[i].insert(0, self._order[i])
-
-        self._order = []
-        for i in range(orderLen):
-            self._order += newOrder[i]
-
-        # construct the new src
+        self._order = list(IT.chain(*newOrder))
         self._src = dict(newSrc)
+        newSrc = []
+        newOrder = []
 
+        # update the src
         orderLen = len(self._order)
+
         for i in range(orderLen):
-            keyData = self._order[i]
-            key = keyData[0]
-            occurence = keyData[1]
+            key, occurence = self._order[i]
+            _, val = self._src[key][occurence]
+            self._src[key][occurence] = (i, val)
+        
+        # update the ordering
+        for key in self._src:
+            keyValData = self._src[key]
+            keyValData.sort(key = lambda valData: valData[0])
+            keyValDataLen = len(keyValData)
 
-            kvpData = self._src[key][occurence]
-
-            self._src[key][occurence] = (i, kvpData[1])
+            for i in range(keyValDataLen):
+                orderInd, val = keyValData[i]
+                self._order[orderInd] = (key, i)
 ##### EndScript

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjReplaceFixer.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjReplaceFixer.py
@@ -103,12 +103,13 @@ class GIMIObjReplaceFixer(GIMIFixer):
 
     def __init__(self, parser: GIMIObjParser, preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None,
                  preRegEditOldObj: bool = True, postModelRegEditFilters: Optional[List[RegEditFilter]] = None, beforeOriginal: bool = False,
-                 postIniProcessor = None):
+                 postIniProcessor = None, nameReplace = None):
         super().__init__(parser, postModelRegEditFilters = postModelRegEditFilters, beforeOriginal = beforeOriginal, postIniProcessor = postIniProcessor)
         self._texInds: Dict[str, Dict[str, int]] = {}
         self._texEditRemapNames: Dict[str, Dict[str, str]] = {}
         self._texAddRemapNames: Dict[str, Dict[str, str]] = {}
         self.preRegEditOldObj = preRegEditOldObj
+        self.nameReplace = nameReplace if (nameReplace is not None) else {}
 
         self.addedTextures: Dict[str, Dict[str, Tuple[str, TexCreator]]] = {}
         self.preRegEditFilters = [] if (preRegEditFilters is None) else preRegEditFilters
@@ -206,11 +207,21 @@ class GIMIObjReplaceFixer(GIMIFixer):
         name = TextTools.reverse(name)
     
         nameParts = re.split(TextTools.reverse(objName), name, flags = re.IGNORECASE, maxsplit = 1)
-        name = TextTools.reverse(TextTools.capitalizeOnlyFirstChar(newObjName)).join(nameParts)
-    
-        name = TextTools.reverse(name)
+        result = ""
 
-        return self._iniFile.getRemapFixName(name, modName = modName)
+        if (len(nameParts) > 1):
+            name = TextTools.reverse(TextTools.capitalizeOnlyFirstChar(newObjName)).join(nameParts)
+            name = TextTools.reverse(name)
+            result = self._iniFile.getRemapFixName(name, modName = modName)
+        else:
+            name = TextTools.reverse(name)
+            result = self._iniFile.getRemapFixName(name, modName = f"{modName}{TextTools.capitalizeOnlyFirstChar(newObjName)}")
+        
+        renameFunc = self.nameReplace.get(newObjName)
+        if (renameFunc is not None):
+            result = renameFunc(result)
+
+        return result
     
     def getTexResourceRemapFixName(self, texTypeName: str, oldModName: str, newModName: str, objName: str, addInd: bool = False) -> str:
         """
@@ -396,7 +407,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
                 newPart.src[varName][keyInd] = (orderInd, f"{newHash}")
 
             # filling in the subcommand
-            elif (varName == IniKeywords.Run.value and varValue != IniKeywords.ORFixPath.value and not varValue.startswith(IniKeywords.TexFxFolder.value)):
+            elif (varName == IniKeywords.Run.value and varValue != IniKeywords.ORFixPath.value and varValue != IniKeywords.NNFixPath.value and not varValue.startswith(IniKeywords.TexFxFolder.value)):
                 subCommand = self.getObjRemapFixName(varValue, modName, objName, newObjName)
                 newPart.src[varName][keyInd] = (orderInd, f"{subCommand}")
 

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjSplitFixer.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/GIMIObjSplitFixer.py
@@ -110,8 +110,8 @@ class GIMIObjSplitFixer(GIMIObjReplaceFixer):
 
     def __init__(self, parser: GIMIObjParser, objs: Dict[str, List[str]], preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, 
                  postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, preRegEditOldObj: bool = False, postModelRegEditFilters: Optional[List[RegEditFilter]] = None, beforeOriginal: bool = False,
-                 postIniProcessor = None):
-        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj, postModelRegEditFilters = postModelRegEditFilters, beforeOriginal = beforeOriginal, postIniProcessor = postIniProcessor)
+                 postIniProcessor = None, nameReplace = None):
+        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj, postModelRegEditFilters = postModelRegEditFilters, beforeOriginal = beforeOriginal, postIniProcessor = postIniProcessor, nameReplace = nameReplace)
         self.objs = objs
 
 

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegRemove.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniFixers/regEditFilters/RegRemove.py
@@ -79,7 +79,7 @@ class RegRemove(RegEditFilter):
         The register removal to do on the current :class:`IfContentPart` being parsed
     """
 
-    def __init__(self, remove: Optional[Dict[str, Set[Union[str, Tuple[str, Callable[[Tuple[int, str]], bool]]]]]] = None):
+    def __init__(self, remove: Optional[Dict[str, Set[Union[str, Tuple[str, Callable[[Tuple[int, str], IfContentPart], bool]]]]]] = None):
         self.remove = {} if (remove is None) else remove
         self._regRemove: Optional[Set[str]] = None
 

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/PackageManager.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/PackageManager.py
@@ -12,6 +12,7 @@
 ##### EndCredits
 
 ##### ExtImports
+import sys
 import pip._internal as pip
 import importlib
 from typing import  Dict, Optional, List
@@ -53,6 +54,10 @@ class PackageManager():
         self._packages: Dict[str, ModuleType] = {}
         self.proxy = proxy
         self.options = [] if (options is None) else options
+
+    @classmethod
+    def inVenv(cls):
+        return sys.prefix != sys.base_prefix
 
     def load(self, module: str, installName: Optional[str] = None, installOptions: Optional[List[str]] = None, save: bool = True) -> ModuleType:
         """
@@ -98,12 +103,18 @@ class PackageManager():
         if (installOptions is None):
             installOptions = []
 
+        options = []
+
+        # Python 3.12+ for linux computers of whether to globally install packages
+        if (sys.platform == "linux" and not self.inVenv()):
+            options.append("--break-system-packages")
+
         try:
             return importlib.import_module(module)
         except ModuleNotFoundError:
             proxyOptions = ["--proxy", self.proxy] if (self.proxy is not None) else []
 
-            pip.main(['install', '-U'] + proxyOptions + self.options + installOptions + [installName])
+            pip.main(['install', '-U'] + proxyOptions + self.options + installOptions + [installName] + options)
 
         result = importlib.import_module(module)
         if (save):

--- a/Anime Game Remap (for all users)/apiMirror/pyproject.toml
+++ b/Anime Game Remap (for all users)/apiMirror/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AnimeGameRemap"
-version = "4.5.5"
+version = "4.6.0"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	"FixRaidenBoss2==4.5.5"
+	"FixRaidenBoss2==4.6.0"
 ]
 
 [project.urls]

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Wednesday, October 29, 2025 10:19:22.609 PM UTC
-# Run Hash: 9548c663-cc6c-4ea3-9d18-081c594299b4
+# Datetime Ran: Friday, November 14, 2025 03:24:45.963 AM UTC
+# Run Hash: 81fd0af7-eb77-4beb-916a-d57f8d5ab03a
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.5.5
+# Version: 4.6.0
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Wednesday, October 29, 2025 10:19:22.609 PM UTC
-# Build Hash: c29998aa-39bd-4056-9b31-967ae3fd1a27
+# Datetime Compiled: Friday, November 14, 2025 03:24:45.963 AM UTC
+# Build Hash: 4d1fbd2d-fd5b-491f-9f0e-e958e51c41d1
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Wednesday, October 29, 2025 10:19:22.609 PM UTC
-# Run Hash: 9548c663-cc6c-4ea3-9d18-081c594299b4
+# Datetime Ran: Friday, November 14, 2025 03:24:45.963 AM UTC
+# Run Hash: 81fd0af7-eb77-4beb-916a-d57f8d5ab03a
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.5.5
+# Version: 4.6.0
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Wednesday, October 29, 2025 10:19:22.609 PM UTC
-# Build Hash: c29998aa-39bd-4056-9b31-967ae3fd1a27
+# Datetime Compiled: Friday, November 14, 2025 03:24:45.963 AM UTC
+# Build Hash: 4d1fbd2d-fd5b-491f-9f0e-e958e51c41d1
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Wednesday, October 29, 2025 10:19:22.133 PM UTC
-# Run Hash: aa1e092d-cb00-4a88-82f2-7bde91410ec6
+# Datetime Ran: Friday, November 14, 2025 03:24:45.478 AM UTC
+# Run Hash: 2e5ad6a6-d338-44e2-b89e-7528f283c178
 # 
 # *******************************
 # ================
@@ -33,16 +33,16 @@
 #
 # ***** AG Remap Script Stats *****
 #
-# Version: 4.5.5
+# Version: 4.6.0
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Wednesday, October 29, 2025 10:19:22.133 PM UTC
-# Build Hash: dd7d758b-6064-4db8-a219-2effe4a1fa7a
+# Datetime Compiled: Friday, November 14, 2025 03:24:45.478 AM UTC
+# Build Hash: 82d89af6-bec6-4159-b436-c4789da5f080
 #
 # *********************************
 #
 
 
-import os, argparse, uuid, heapq, pip._internal as pip, importlib, re, shutil, ntpath, copy, hashlib, json, traceback, struct, configparser
+import os, argparse, uuid, heapq, sys, pip._internal as pip, importlib, re, shutil, ntpath, copy, itertools as IT, hashlib, json, traceback, struct, configparser
 
 from typing import List, Tuple, Any, Callable, Union, Set, TypeVar, Optional, Dict, Type, Hashable, Generic, TYPE_CHECKING, DefaultDict
 from collections import OrderedDict, deque, defaultdict, UserDict
@@ -2006,6 +2006,10 @@ class PackageManager():
         self.proxy = proxy
         self.options = [] if (options is None) else options
 
+    @classmethod
+    def inVenv(cls):
+        return sys.prefix != sys.base_prefix
+
     def load(self, module: str, installName: Optional[str] = None, installOptions: Optional[List[str]] = None, save: bool = True) -> ModuleType:
         """
         Imports an external package
@@ -2050,12 +2054,18 @@ class PackageManager():
         if (installOptions is None):
             installOptions = []
 
+        options = []
+
+        # Python 3.12+ for linux computers of whether to globally install packages
+        if (sys.platform == "linux" and not self.inVenv()):
+            options.append("--break-system-packages")
+
         try:
             return importlib.import_module(module)
         except ModuleNotFoundError:
             proxyOptions = ["--proxy", self.proxy] if (self.proxy is not None) else []
 
-            pip.main(['install', '-U'] + proxyOptions + self.options + installOptions + [installName])
+            pip.main(['install', '-U'] + proxyOptions + self.options + installOptions + [installName] + options)
 
         result = importlib.import_module(module)
         if (save):
@@ -6778,7 +6788,10 @@ class IfContentPart(IfTemplatePart):
     
     @src.setter
     def src(self, newSrc: Dict[str, List[Tuple[int, str]]]):
-        self._src = newSrc
+        self._src = copy.copy(newSrc)
+        for key in self._src:
+            self._src[key] = sorted(self._src[key], key = lambda data: data[0])
+
         self._setupOrder()
 
     def _setupOrder(self):
@@ -6855,7 +6868,7 @@ class IfContentPart(IfTemplatePart):
         keyData = self._order[orderInd]
         self._order[orderInd] = (keyData[0], newInd)
     
-    def removeKey(self, key: Union[str, Tuple[str, Callable[[Tuple[int, str]], bool]]]):
+    def removeKey(self, key: Union[str, Tuple[str, Callable[[Tuple[int, str], "IfContentPart"], bool]]]):
         """
         Removes a key from the part.
 
@@ -6874,7 +6887,7 @@ class IfContentPart(IfTemplatePart):
 
         orderIndsToRemove = set()
         values = None
-        pred = lambda val: True
+        pred = lambda val, part: True
         targetKey = key
 
         if (isinstance(key, tuple) and len(key) >= 2):
@@ -6891,7 +6904,7 @@ class IfContentPart(IfTemplatePart):
 
         for i in range(valuesLen):
             value = values[i]
-            if (pred(value)):
+            if (pred(value, self)):
                 orderIndsToRemove.add(value[0])
                 currentValRemovedInds.add(i)
 
@@ -6915,7 +6928,7 @@ class IfContentPart(IfTemplatePart):
             valData = self.src[orderData[0]][orderData[1]]
             self.src[orderData[0]][orderData[1]] = (i, valData[1])
 
-    def removeKeys(self, keys: Set[Union[str, Tuple[str, Callable[[Tuple[int, str]], bool]]]]):
+    def removeKeys(self, keys: Set[Union[str, Tuple[str, Callable[[Tuple[int, str], "IfContentPart"], bool]]]]):
         """
         Removes multiple keys from the part
 
@@ -6935,7 +6948,7 @@ class IfContentPart(IfTemplatePart):
         orderIndsToRemove = set()
 
         for key in keys:
-            pred = lambda val: True
+            pred = lambda val, part: True
             targetKey = key
 
             if (isinstance(key, tuple) and len(key) >= 2):
@@ -6953,7 +6966,7 @@ class IfContentPart(IfTemplatePart):
 
             for i in range(valuesLen):
                 value = values[i]
-                if (pred(value)):
+                if (pred(value, self)):
                     orderIndsToRemove.add(value[0])
                     currentValRemovedInds.add(i)
 
@@ -7122,6 +7135,63 @@ class IfContentPart(IfTemplatePart):
                 valData = self.src[key][i]
                 self.src[key][i] = (valData[0], vals[i])
 
+    def reorder(self, orderMap: Dict[int, int]):
+        """
+        Reorders the `KVPs`_
+
+        Parameters
+        ----------
+        orderMap: Dict[:class:`int`, :class:`int`]
+            The mapping of how to reorder the `KVPs`_ :raw-html:`<br />` :raw-html:`<br />`
+
+            The keys are the original indices of the `KVPs`_ and the values are the new indices for the `KVPs`_
+        """
+
+        newOrder = []
+        orderLen = len(self._order)
+
+        for i in range(orderLen + 1):
+            currentOrderPart = deque()
+            if (i < orderLen and i not in orderMap):
+                currentOrderPart.append(self._order[i])
+
+            newOrder.append(currentOrderPart)
+
+        # move the kvps
+        for fromInd in orderMap:
+            toInd = orderMap[fromInd]
+            keyData = self._order[fromInd]
+
+            if (toInd > orderLen):
+                toInd = orderLen
+            elif (-orderLen - 1 < toInd < 0):
+                toInd = orderLen + 1 + toInd
+            elif (toInd <= -orderLen - 1):
+                toInd = 0
+
+            newOrder[toInd].append(keyData)
+
+        # update the src
+        newOrder = list(IT.chain(*newOrder))
+        orderLen = len(newOrder)
+
+        for i in range(orderLen):
+            key, occurence = newOrder[i]
+            _, val = self._src[key][occurence]
+            self._src[key][occurence] = (i, val)
+        
+        # update the ordering
+        for key in self._src:
+            keyValData = self._src[key]
+            keyValData.sort(key = lambda valData: valData[0])
+            keyValDataLen = len(keyValData)
+
+            for i in range(keyValDataLen):
+                orderInd, val = keyValData[i]
+                newOrder[orderInd] = (key, i)
+
+        self._order = newOrder
+
     def remapKeys(self, keyRemap: Dict[str, Union[KeyRemapData, List[Union[str, Tuple[str, Callable[[str, str], bool]], RemappedKeyData]]]]):
         """
         Remaps the keys in the `KVP`_s of the parts
@@ -7142,7 +7212,6 @@ class IfContentPart(IfTemplatePart):
                     * A class that contains all the necessary information for remapping to the new key
         """
 
-        occurences = defaultdict(lambda: 0)
         i = 0
         orderLen = len(self._order)
         keysToRemove = set()
@@ -7150,10 +7219,8 @@ class IfContentPart(IfTemplatePart):
         convertedKeyRemap = {}
 
         newOrder = []
-        orderNewOccurences = []
-        for i in range(orderLen):
+        for i in range((orderLen + 1) * 2):
             newOrder.append([])
-            orderNewOccurences.append(-1)
 
         newSrc = defaultdict(lambda: [])
         for key in self._src:
@@ -7162,21 +7229,16 @@ class IfContentPart(IfTemplatePart):
         for i in range(orderLen):
             keyData = self._order[i]
             key = keyData[0]
-            keyOccurence = keyData[1]
-            currentMaxOccurence = occurences[key]
-            
-            # update the occurence of the key
-            if (keyOccurence < currentMaxOccurence):
-                self._order[i] = (key, currentMaxOccurence)
-                orderNewOccurences[i] = currentMaxOccurence
+            fromKeyOccurence = keyData[1]
+            newFromKeyOccurence = len(newSrc[key])
 
-            keyValData = self.src[key][keyOccurence]
+            keyValData = self.src[key][fromKeyOccurence]
             keyVal = keyValData[1]
 
             inKeyRemap = key in keyRemap
             if (not inKeyRemap):
-                occurences[key] += 1
-                newSrc[key].append((i, keyVal))
+                newSrc[key].append((-1, keyVal))
+                newOrder[i * 2].append((key, newFromKeyOccurence))
                 continue
 
             newKeys = keyRemap[key]
@@ -7199,21 +7261,34 @@ class IfContentPart(IfTemplatePart):
                 if (check is not None and not check(key, keyVal)):
                     continue
 
+                toKeyOccurence = len(newSrc[newKey])
+
                 if (not keyRemapped):
                     keyRemapped = True
 
-                if (toInd is None):
+                hasToInd = toInd is not None
+                if (not hasToInd):
                     toInd = i
 
-                newOrder[toInd].append((newKey, occurences[newKey]))
+                if (toInd >= orderLen):
+                    toInd = orderLen
+                elif (-orderLen - 1 < toInd < 0):
+                    toInd = orderLen + 1 + toInd
+                elif (toInd <= -orderLen - 1):
+                    toInd = 0
+
+                toInd *= 2
+                if (hasToInd):
+                    toInd += 1
+
+                newOrder[toInd].append((newKey, toKeyOccurence))
                 newSrc[newKey].append((-1, keyVal))
 
                 keysToAdd.add(newKey)
-                occurences[newKey] += 1
 
             if (not keyRemapped and keepKeyWithoutRemap):
-                occurences[key] += 1
-                newSrc[key].append((i, keyVal))
+                newSrc[key].append((-1, keyVal))
+                newOrder[i * 2].append((key, newFromKeyOccurence))
 
             if (not keepKeyWithoutRemap or (keyRemapped and keepKeyWithoutRemap)):
                 keysToRemove.add(key)
@@ -7223,30 +7298,28 @@ class IfContentPart(IfTemplatePart):
             if (key not in keysToAdd):
                 del newSrc[key]
 
-        # construct the new order
-        for i in range(orderLen):
-            keyData = self._order[i]
-            key = keyData[0]
-
-            if (key not in keysToRemove):
-                newOrder[i].insert(0, self._order[i])
-
-        self._order = []
-        for i in range(orderLen):
-            self._order += newOrder[i]
-
-        # construct the new src
+        self._order = list(IT.chain(*newOrder))
         self._src = dict(newSrc)
+        newSrc = []
+        newOrder = []
 
+        # update the src
         orderLen = len(self._order)
+
         for i in range(orderLen):
-            keyData = self._order[i]
-            key = keyData[0]
-            occurence = keyData[1]
+            key, occurence = self._order[i]
+            _, val = self._src[key][occurence]
+            self._src[key][occurence] = (i, val)
+        
+        # update the ordering
+        for key in self._src:
+            keyValData = self._src[key]
+            keyValData.sort(key = lambda valData: valData[0])
+            keyValDataLen = len(keyValData)
 
-            kvpData = self._src[key][occurence]
-
-            self._src[key][occurence] = (i, kvpData[1])
+            for i in range(keyValDataLen):
+                orderInd, val = keyValData[i]
+                self._order[orderInd] = (key, i)
 
 
 class IfTemplateNode(Node):
@@ -16922,12 +16995,13 @@ class GIMIObjReplaceFixer(GIMIFixer):
 
     def __init__(self, parser: GIMIObjParser, preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, postRegEditFilters: Optional[List[BaseRegEditFilter]] = None,
                  preRegEditOldObj: bool = True, postModelRegEditFilters: Optional[List[RegEditFilter]] = None, beforeOriginal: bool = False,
-                 postIniProcessor = None):
+                 postIniProcessor = None, nameReplace = None):
         super().__init__(parser, postModelRegEditFilters = postModelRegEditFilters, beforeOriginal = beforeOriginal, postIniProcessor = postIniProcessor)
         self._texInds: Dict[str, Dict[str, int]] = {}
         self._texEditRemapNames: Dict[str, Dict[str, str]] = {}
         self._texAddRemapNames: Dict[str, Dict[str, str]] = {}
         self.preRegEditOldObj = preRegEditOldObj
+        self.nameReplace = nameReplace if (nameReplace is not None) else {}
 
         self.addedTextures: Dict[str, Dict[str, Tuple[str, TexCreator]]] = {}
         self.preRegEditFilters = [] if (preRegEditFilters is None) else preRegEditFilters
@@ -17025,11 +17099,21 @@ class GIMIObjReplaceFixer(GIMIFixer):
         name = TextTools.reverse(name)
     
         nameParts = re.split(TextTools.reverse(objName), name, flags = re.IGNORECASE, maxsplit = 1)
-        name = TextTools.reverse(TextTools.capitalizeOnlyFirstChar(newObjName)).join(nameParts)
-    
-        name = TextTools.reverse(name)
+        result = ""
 
-        return self._iniFile.getRemapFixName(name, modName = modName)
+        if (len(nameParts) > 1):
+            name = TextTools.reverse(TextTools.capitalizeOnlyFirstChar(newObjName)).join(nameParts)
+            name = TextTools.reverse(name)
+            result = self._iniFile.getRemapFixName(name, modName = modName)
+        else:
+            name = TextTools.reverse(name)
+            result = self._iniFile.getRemapFixName(name, modName = f"{modName}{TextTools.capitalizeOnlyFirstChar(newObjName)}")
+        
+        renameFunc = self.nameReplace.get(newObjName)
+        if (renameFunc is not None):
+            result = renameFunc(result)
+
+        return result
     
     def getTexResourceRemapFixName(self, texTypeName: str, oldModName: str, newModName: str, objName: str, addInd: bool = False) -> str:
         """
@@ -17215,7 +17299,7 @@ class GIMIObjReplaceFixer(GIMIFixer):
                 newPart.src[varName][keyInd] = (orderInd, f"{newHash}")
 
             # filling in the subcommand
-            elif (varName == IniKeywords.Run.value and varValue != IniKeywords.ORFixPath.value and not varValue.startswith(IniKeywords.TexFxFolder.value)):
+            elif (varName == IniKeywords.Run.value and varValue != IniKeywords.ORFixPath.value and varValue != IniKeywords.NNFixPath.value and not varValue.startswith(IniKeywords.TexFxFolder.value)):
                 subCommand = self.getObjRemapFixName(varValue, modName, objName, newObjName)
                 newPart.src[varName][keyInd] = (orderInd, f"{subCommand}")
 
@@ -17730,7 +17814,7 @@ class RegRemove(RegEditFilter):
         The register removal to do on the current :class:`IfContentPart` being parsed
     """
 
-    def __init__(self, remove: Optional[Dict[str, Set[Union[str, Tuple[str, Callable[[Tuple[int, str]], bool]]]]]] = None):
+    def __init__(self, remove: Optional[Dict[str, Set[Union[str, Tuple[str, Callable[[Tuple[int, str], IfContentPart], bool]]]]]] = None):
         self.remove = {} if (remove is None) else remove
         self._regRemove: Optional[Set[str]] = None
 
@@ -17843,8 +17927,8 @@ class GIMIObjSplitFixer(GIMIObjReplaceFixer):
 
     def __init__(self, parser: GIMIObjParser, objs: Dict[str, List[str]], preRegEditFilters: Optional[List[BaseRegEditFilter]] = None, 
                  postRegEditFilters: Optional[List[BaseRegEditFilter]] = None, preRegEditOldObj: bool = False, postModelRegEditFilters: Optional[List[RegEditFilter]] = None, beforeOriginal: bool = False,
-                 postIniProcessor = None):
-        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj, postModelRegEditFilters = postModelRegEditFilters, beforeOriginal = beforeOriginal, postIniProcessor = postIniProcessor)
+                 postIniProcessor = None, nameReplace = None):
+        super().__init__(parser, preRegEditFilters = preRegEditFilters, postRegEditFilters = postRegEditFilters, preRegEditOldObj = preRegEditOldObj, postModelRegEditFilters = postModelRegEditFilters, beforeOriginal = beforeOriginal, postIniProcessor = postIniProcessor, nameReplace = nameReplace)
         self.objs = objs
 
 
@@ -18468,22 +18552,30 @@ class RegTexEdit(RegEditFilter):
 # IniFixBuilderFunc: Class to define how the IniFixBuilder arguments for some
 #   mod are built for a particular game version
 class IniFixBuilderFuncs():
-    def _regIsTexFxWrapper(val: Tuple[int, str]) -> bool:
+    def _regIsTexFxWrapper(val: Tuple[int, str], part) -> bool:
         return val[1].lower().find(IniKeywords.TexFxFolder.value.lower()) > -1
     
-    def _regValIsOrFixWrapper(val: Tuple[int, str]) -> bool:
+    def _regValIsOrFixWrapper(val: Tuple[int, str], part) -> bool:
         return val[1] == IniKeywords.ORFixPath.value
     
-    def _regValIsNnFixWrapper(val: Tuple[int, str]) -> bool:
+    def _regValIsNnFixWrapper(val: Tuple[int, str], part) -> bool:
         return val[1] == IniKeywords.NNFixPath.value
     
     @classmethod
-    def _regIsTex(cls, val: Tuple[int, str]) -> bool:
+    def _regIsTex(cls, val: Tuple[int, str], part) -> bool:
         return cls._regIsTexFxWrapper(val)
     
     @classmethod
-    def _regValIsOrFix(cls, val: Tuple[int, str]) -> bool:
+    def _regValIsOrFix(cls, val: Tuple[int, str], part) -> bool:
         return cls._regValIsOrFixWrapper(val)
+    
+    @classmethod
+    def _hasNullIb(self, val: Tuple[int, str], part):
+        ibVals = part.get("ib")
+        if (not ibVals):
+            return False
+        
+        return bool(ibVals[-1][1] == "null")
 
     TexFxRemove = {("run", _regIsTexFxWrapper)}
     TexFxTempReg = "tempTexFx"
@@ -18496,14 +18588,19 @@ class IniFixBuilderFuncs():
     
     ORFixRemove = {("run", _regValIsOrFixWrapper)}
     NNFixRemove = {("run", _regValIsNnFixWrapper)}
-    ReflectionHeadRemove = {"ResourceRefHeadDiffuse", "ResourceRefHeadLightMap", "$CharacterIB", *ORFixRemove}
-    ReflectionBodyRemove = {"ResourceRefBodyDiffuse", "ResourceRefBodyLightMap", "$CharacterIB", *ORFixRemove}
-    ReflectionDressRemove = {"ResourceRefDressDiffuse", "ResourceRefDressLightMap", "$CharacterIB", *ORFixRemove}
-    ReflectionExtraRemove = {"ResourceRefExtraDiffuse", "ResourceRefExtraLightMap", "$CharacterIB", *ORFixRemove}
+    ORFixCompleteRemoval = {*ORFixRemove, *NNFixRemove}
+    ReflectionHeadRemove = {"ResourceRefHeadDiffuse", "ResourceRefHeadLightMap", "$CharacterIB", *ORFixCompleteRemoval}
+    ReflectionBodyRemove = {"ResourceRefBodyDiffuse", "ResourceRefBodyLightMap", "$CharacterIB", *ORFixCompleteRemoval}
+    ReflectionDressRemove = {"ResourceRefDressDiffuse", "ResourceRefDressLightMap", "$CharacterIB", *ORFixCompleteRemoval}
+    ReflectionExtraRemove = {"ResourceRefExtraDiffuse", "ResourceRefExtraLightMap", "$CharacterIB", *ORFixCompleteRemoval}
 
     ORFixTempReg = "tempORFix"
     ORFixValRename = {ORFixTempReg: IniKeywords.ORFixPath.value}
     ORFixTempToRun = {ORFixTempReg: [RemappedKeyData("run", toInd = -1)]}
+
+    NNFixTempReg = "tempNNFix"
+    NNFixValRename = {NNFixTempReg: IniKeywords.NNFixPath.value}
+    NNFixTempToRun = {NNFixTempReg: [RemappedKeyData("run", toInd = -1)]}
 
     DrawIndexedTempReg = "tempDrawIndexed"
     IbRemappedData = RemappedKeyData(DrawIndexedTempReg, toInd = -1)
@@ -18549,7 +18646,7 @@ class IniFixBuilderFuncs():
         return cls._isShadow(val)
     
     @classmethod
-    def _removeIsNormalMap(cls, val: Tuple[int, str]) -> bool:
+    def _removeIsNormalMap(cls, val: Tuple[int, str], part) -> bool:
         return cls._isNormalMap(val[1])
     
     # =======================================================
@@ -18574,6 +18671,23 @@ class IniFixBuilderFuncs():
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def amber6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, [],
+                {"postRegEditFilters": [RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                            "body": cls.ORFixCompleteRemoval}),
+                                        RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                          "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                        RegRemap(remap = {"head": cls.IbRemapData,
+                                                          "body": cls.IbRemapData}),
+                                        RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                                           "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                                        RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                                          "body": cls.NNFixTempToRun}),
+                                        RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                                          "body": cls.IbTempToDrawIndexed})],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def amberCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
     
@@ -18584,6 +18698,23 @@ class IniFixBuilderFuncs():
                                                           "body": cls.IbRemapData}),
                                         RegNewVals(vals = {"head": cls.IbDrawIndexedRename,
                                                            "body": cls.IbDrawIndexedRename}),
+                                        RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                                          "body": cls.IbTempToDrawIndexed})],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+
+    @classmethod
+    def amberCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, [],
+                {"postRegEditFilters": [RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                            "body": cls.ORFixCompleteRemoval}),
+                                        RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                          "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                        RegRemap(remap = {"head": cls.IbRemapData,
+                                                          "body": cls.IbRemapData}),
+                                        RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                                           "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                                        RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                                          "body": cls.NNFixTempToRun}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
@@ -18683,6 +18814,30 @@ class IniFixBuilderFuncs():
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def ayaka6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                       RegRemove(remove = {"head": {"ps-t2", *cls.ORFixCompleteRemoval},
+                                           "body": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                           "dress": {*cls.ORFixCompleteRemoval}}),
+                       RegTexEdit({"BrightLightMap": ["ps-t1"], "OpaqueDiffuse": ["ps-t0"], "TransparentDiffuse": ["ps-t0"]}),
+                       RegRemap(remap = {"head": {"ps-t1": ["ps-t2", cls.ORFixTempReg], "ps-t0": ["ps-t0", "ps-t1"], **cls.IbRemapData},
+                                         "body": {"ps-t2": ["ps-t3"], "ps-t1": ["ps-t2", cls.ORFixTempReg], "ps-t0": ["ps-t0", "ps-t1"], **cls.IbRemapData},
+                                         "dress": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                       RegTexAdd(textures = {"head": {"ps-t0": ("NormalMap", TexCreator(1024, 1024, colour = Colours.NormalMapPurple1.value))},
+                                             "body": {"ps-t0": ("NormalMap", TexCreator(1024, 1024, colour = Colours.NormalMapPurple1.value))}}, mustAdd = False),
+                       RegNewVals({"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename},
+                                   "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename},
+                                   "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                       RegRemap(remap = {"head": {**cls.ORFixTempToRun, **cls.IbTempToDrawIndexed},
+                                         "body": {**cls.ORFixTempToRun, **cls.IbTempToDrawIndexed},
+                                         "dress": {**cls.NNFixTempToRun, **cls.IbTempToDrawIndexed}})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+
+    @classmethod
     def ayakaSpringbloom4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [], 
@@ -18755,7 +18910,39 @@ class IniFixBuilderFuncs():
                 "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
-
+    
+    @classmethod
+    def ayakaSpringbloom6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["body", "body"], "body": ["head", "body"], "dress": ["dress", "dress"]}], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t3", *cls.ReflectionHeadRemove},
+                                        "body": {*cls.ReflectionBodyRemove}}),
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t2", (cls.ORFixTempReg, cls._remapIsShadow)], **cls.IbRemapData},
+                                      "body": {"ps-t2": ["ps-t2", (cls.ORFixTempReg, cls._remapIsShadow)], **cls.IbRemapData}}),
+                    RegTexEdit(textures = {"HeadShadeLightMap": [("ps-t2", cls._remapIsShadow)], 
+                                           "HeadAltShadeLightMap": [("ps-t1", cls._remapIsShadow)],
+                                           "BodyTransparentDiffuse": [("ps-t1", cls._remapIsLightMap)],
+                                           "BodyAltTransparentDiffuse": [("ps-t0", cls._remapIsLightMap)],
+                                           "BodyOpaqueGreenLightMap": [("ps-t2", cls._remapIsShadow)],  
+                                           "BodyAltOpaqueGreenLightMap": [("ps-t1", cls._remapIsShadow)]}),
+                    RegNewVals(vals = {"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.ORFixTempToRun},
+                                      "body": {**cls.ORFixTempToRun}}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"dress": {"ps-t3", *cls.ReflectionDressRemove}}),
+                    RegRemap({"dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals({"head": {"ib": "null"}, "dress": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap({"dress": {**cls.NNFixTempToRun}}),
+                    RegRemap({"dress": {**cls.IbTempToDrawIndexed}})
+                ],
+                "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
     
     @classmethod
     def arlecchino5_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18806,6 +18993,29 @@ class IniFixBuilderFuncs():
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def barbara6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {"postRegEditFilters": [
+                    RegRemove({"head": cls.ORFixCompleteRemoval,
+                               "body": cls.ORFixCompleteRemoval,
+                               "dress": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                      "body": cls.NNFixTempToRun,
+                                      "dress": cls.NNFixTempToRun}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def barbaraSummertime4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
     
@@ -18820,6 +19030,29 @@ class IniFixBuilderFuncs():
                     RegNewVals(vals = {"head": cls.IbDrawIndexedRename,
                                        "body": cls.IbDrawIndexedRename,
                                        "dress": cls.IbDrawIndexedRename}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+
+    @classmethod
+    def barbaraSummertime6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {"postRegEditFilters": [
+                   RegRemove({"head": cls.ORFixCompleteRemoval,
+                               "body": cls.ORFixCompleteRemoval,
+                               "dress": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                      "body": cls.NNFixTempToRun,
+                                      "dress": cls.NNFixTempToRun}),
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
@@ -18849,6 +19082,38 @@ class IniFixBuilderFuncs():
                                            "dress": {**cls.TexFXTempToRun}})
                 ],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value})
+
+    @classmethod
+    def cherryHuTao6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "extra"], "body": ["body", "dress"]}], 
+                {
+                 "preRegEditFilters": [
+                         RegRemove(remove = {"head": {*cls.ReflectionHeadRemove, *cls.TexFxRemove},
+                                             "body": {*cls.ReflectionBodyRemove},
+                                             "dress": {*cls.ReflectionDressRemove, *cls.TexFxRemove},
+                                             "extra": {*cls.ReflectionExtraRemove}}),
+                         RegTexEdit(textures = {"TransparentBodyDiffuse": ["ps-t0"],
+                                                "TransparentyDressDiffuse": ["ps-t1"],
+                                                "OpaqueBodyLightMap": ["ps-t1"]}),
+                         RegRemove(remove = {"head": {"ps-t0"},
+                                             "dress": {"ps-t0"}}),
+                         RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap},
+                                           "dress": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap},
+                                           "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                           "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                         RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0},
+                                            "dress": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0},
+                                            "body": {**cls.NNFixValRename},
+                                            "extra": {**cls.NNFixValRename}}),
+                         RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                           "body": {**cls.NNFixTempToRun},
+                                           "dress": {**cls.NNFixTempToRun},
+                                           "extra": {**cls.NNFixTempToRun}}),
+                         RegRemap(remap = {"head": {**cls.TexFXTempToRun},
+                                           "dress": {**cls.TexFXTempToRun}})
+                ],
+                "copyPreamble": IniComments.GIMIObjMergerPreamble.value})
     
     @classmethod
     def diluc4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18869,6 +19134,25 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                 ],
+                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
+    def diluc6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"body": ["body", "dress"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
                  "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
@@ -18901,6 +19185,29 @@ class IniFixBuilderFuncs():
                  "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
     
     @classmethod
+    def dilucFlamme6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegTexEdit({"TransparentBodyDiffuse": ["ps-t0"], "TransparentDressDiffuse": ["ps-t0"]})
+                 ],
+                 "postRegEditFilters":  [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
+                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+    
+    @classmethod
     def fischl4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjMergeFixer, 
                 [{"body": ["body", "dress"]}], 
@@ -18922,7 +19229,26 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed})
                  ],
                  "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
-
+    
+    @classmethod
+    def fischl6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                 "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
+                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
     
     @classmethod
     def fischlHighness4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18954,7 +19280,31 @@ class IniFixBuilderFuncs():
                     RegNewVals({"dress": {"ib": "null"}})
                 ],
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
-
+    
+    @classmethod
+    def fischlHighness6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"body": ["body", "dress"]}], 
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg], **cls.IbRemapData}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.NNFixValRename, **cls.IbDrawIndexedRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
+                                      "body": {**cls.IbTempToDrawIndexed}})
+                 ],
+                 "postRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}}),
+                    RegNewVals({"dress": {"ib": "null"}})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
     def ganyu4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18994,6 +19344,33 @@ class IniFixBuilderFuncs():
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def ganyu6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.TexFxRemove, *cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2", cls.ORFixTempReg], **cls.TexFxTempRegRemap, **cls.IbRemapData},
+                                      "body": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegTexEdit(textures = {"DarkDiffuse": ["ps-t1"]}),
+                    RegTexAdd(textures = {"head": {"ps-t0": ("NormalMap", TexCreator(1024, 1024, colour = Colours.NormalMapYellow.value))}}),
+                    RegNewVals(vals = {"head": {**cls.ORFixValRename, **cls.TexFXToNormalValRename5_0, **cls.IbDrawIndexedRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.ORFixTempToRun,
+                                      "body": cls.NNFixTempToRun,
+                                      "dress": cls.NNFixTempToRun}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def ganyuTwilight4_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [], 
@@ -19023,6 +19400,31 @@ class IniFixBuilderFuncs():
                                        "body": cls.IbDrawIndexedRename,
                                        "dress": cls.IbDrawIndexedRename}),
                     RegRemap(remap = {"head": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed,
+                                      "dress": cls.IbTempToDrawIndexed})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
+    def ganyuTwilight6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t0", *cls.ReflectionHeadRemove, *cls.TexFxRemove},
+                                        "body": {*cls.ReflectionBodyRemove},
+                                        "dress": {*cls.ReflectionDressRemove}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap, **cls.IbRemapData},
+                                      "body": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {**cls.IbRemapData, "ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.TexFxNoNormalValRename5_0, **cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "body": {**cls.IbDrawIndexedRename, **cls.NNFixValRename},
+                                       "dress": {**cls.IbDrawIndexedRename, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}}),
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
@@ -19088,6 +19490,39 @@ class IniFixBuilderFuncs():
                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
     
     @classmethod
+    def hutao6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head", "extra"], "body": ["body", "dress"]}],
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"},
+                                        "body": {"ps-t2", "ps-t3"}}),
+                    RegRemap(remap = {"head": cls.IbRemapData,
+                                      "body": cls.IbRemapData}),
+                    RegNewVals(vals = {"head": cls.IbDrawIndexedRename,
+                                       "body": cls.IbDrawIndexedRename}),
+                    RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
+                                      "body": cls.IbTempToDrawIndexed})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.TexFxRemove},
+                                        "dress": {*cls.TexFxRemove},
+                                        "extra": {"ps-t0", "ps-t1"}}),
+                    RegNewVals(vals = {"extra": {IniKeywords.Ib.value: "null"}, 
+                                       "dress": {IniKeywords.Ib.value: "null"}}),
+                    RegTexEdit(textures = {"TransparentHeadDiffuse": ["ps-t0"]}),
+                    RegRemap(remap = {"head": {"ps-t0": ["ps-t0", "ps-t2"], **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2"], **cls.TexFxTempRegRemap}}),
+                    RegNewVals(vals = {"head": {"ps-t0": "null", **cls.TexFXToNormalValRename5_0},
+                                       "dress": {**cls.TexFXToNormalValRename5_0}}),
+                    RegTexAdd(textures = {"dress": {"ps-t0": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapBlue.value))}}, mustAdd = False),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun},
+                                      "dress": {**cls.TexFXTempToRun}})
+                ],
+                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+    
+    @classmethod
     def jean4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (MultiModFixer, 
                 [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer), 
@@ -19100,11 +19535,12 @@ class IniFixBuilderFuncs():
                 [{ModTypeNames.Jean.value: IniFixBuilder(GIMIObjRegEditFixer), 
                   ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, args = [{"body": ["body", "dress"]}])}],
                 {})
-    
+
     @classmethod
     def jean5_5(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (MultiModFixer, 
-                [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer, kwargs = {}), 
+                [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer, 
+                                                           kwargs = {}), 
                   ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, 
                                                             args = [{"body": ["body", "dress"]}],
                                                             kwargs = {
@@ -19117,13 +19553,81 @@ class IniFixBuilderFuncs():
                 {})
     
     @classmethod
+    def jean6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (MultiModFixer, 
+                [{ModTypeNames.JeanCN.value: IniFixBuilder(GIMIObjRegEditFixer, 
+                                                           kwargs = {"preRegEditFilters": [
+                                                                RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                    "body": cls.ORFixCompleteRemoval}),
+                                                                RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                "body": {**cls.NNFixValRename}}),
+                                                                RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                "body": {**cls.NNFixTempToRun}})
+                                                           ]}), 
+                  ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, args = [{"body": ["body", "dress"]}],
+                                                            kwargs = {
+                                                                "preRegEditOldObj": True,
+                                                                "preRegEditFilters": [
+                                                                RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                    "body": cls.ORFixCompleteRemoval}),
+                                                                RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                "body": {**cls.NNFixValRename}}),
+                                                                RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                "body": {**cls.NNFixTempToRun}}),
+                                                            ],
+                                                            "postRegEditFilters": [
+                                                                    RegNewVals(vals = {"dress": {"ib": "null"}}),
+                                                                    RegTexEdit(textures = {"ShadeLightMap": ["ps-t1"]})
+                                                            ]})}],
+                {})
+    
+    @classmethod
     def jeanCN5_5(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (MultiModFixer, 
                 [{ModTypeNames.Jean.value: IniFixBuilder(GIMIObjRegEditFixer, kwargs = {}), 
                   ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, 
-                                                            args = [{"body": ["body", "dress"]}],
+                                                            args = [{"head": ["head"], "body": ["body", "dress"]}],
                                                             kwargs = {
                                                                 
+                                                                "postRegEditFilters": [
+                                                                    RegNewVals(vals = {"dress": {"ib": "null"}}),
+                                                                    RegTexEdit(textures = {"ShadeLightMap": ["ps-t1"]})
+                                                                ]
+                                                            })}],
+                {})
+    
+    @classmethod
+    def jeanCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (MultiModFixer, 
+                [{ModTypeNames.Jean.value: IniFixBuilder(GIMIObjRegEditFixer, 
+                                                         kwargs = {"preRegEditFilters": [
+                                                                RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                    "body": cls.ORFixCompleteRemoval}),
+                                                                RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                "body": {**cls.NNFixValRename}}),
+                                                                RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                "body": {**cls.NNFixTempToRun}})
+                                                           ]}), 
+                  ModTypeNames.JeanSea.value: IniFixBuilder(GIMIObjSplitFixer, 
+                                                            args = [{"head": ["head"], "body": ["body", "dress"]}],
+                                                            kwargs = {
+                                                                "preRegEditOldObj": True,
+                                                                "preRegEditFilters": [
+                                                                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                                                                        "body": cls.ORFixCompleteRemoval}),
+                                                                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                                                                    "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                                                                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                                                                    "body": {**cls.NNFixValRename}}),
+                                                                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                                                                    "body": {**cls.NNFixTempToRun}}),
+                                                                ],
                                                                 "postRegEditFilters": [
                                                                     RegNewVals(vals = {"dress": {"ib": "null"}}),
                                                                     RegTexEdit(textures = {"ShadeLightMap": ["ps-t1"]})
@@ -19137,6 +19641,23 @@ class IniFixBuilderFuncs():
                 [{"body": ["body", "dress"]}], 
                 {
                  "copyPreamble": IniComments.GIMIObjMergerPreamble.value})
+
+    @classmethod
+    def jeanSea6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                    "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                    "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                    "body": {**cls.NNFixTempToRun}}),
+                    ]})
     
     @classmethod
     def kaeya4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19162,6 +19683,27 @@ class IniFixBuilderFuncs():
                     RegNewVals(vals = {"body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFXToNormalValRename5_0}}),
                     RegRemap(remap = {"body": {**cls.TexFXTempToRun}}),
                     RegRemap(remap = {"body": cls.ORFixTempToRun})
+                ]})
+    
+    @classmethod
+    def kaeya6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer,
+                [],
+                {"postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.TexFxRemove, *cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t0": ["ps-t0", "ps-t1"], "ps-t1": ["ps-t2", cls.ORFixTempReg], "ps-t2": ["ps-t3"], **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegTexAdd(textures = {"body": {"ps-t0": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapYellow.value))}}, mustAdd = False),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFXToNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"body": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.NNFixTempToRun,
+                                      "body": cls.ORFixTempToRun,
+                                      "dress": cls.NNFixTempToRun})
                 ]})
     
     @classmethod
@@ -19191,12 +19733,53 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def kaeyaSailwind6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer,
+                [{"head": ["head"], "body": ["body"], "dress": ["dress", "extra"]}],
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ReflectionHeadRemove},
+                                        "body": {*cls.ReflectionBodyRemove, *cls.TexFxRemove},
+                                        "dress": {*cls.ReflectionDressRemove}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], "ps-t3": ["ps-t2"], **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"body": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def keqing4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjMergeFixer, 
                 [{"head": ["dress", "head"]}], 
                 {
-                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, "preRegEditFilters": [
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
                     RegTexEdit({"OpaqueDressDiffuse": ["ps-t0"], "OpaqueHeadDiffuse": ["ps-t0"]})
+                ]})
+    
+    @classmethod
+    def keqing6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["dress", "head"], "body": ["body"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegTexEdit({"OpaqueDressDiffuse": ["ps-t0"], "OpaqueHeadDiffuse": ["ps-t0"]})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -19205,6 +19788,25 @@ class IniFixBuilderFuncs():
                 [{"head": ["head"], "body": ["body", "dress"]}], 
                 {"preRegEditFilters": [
                     RegTexEdit(textures = {"NonReflectiveLightMap": ["ps-t1"]})
+                ]})
+    
+    @classmethod
+    def keqingOpulent6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ],
+                 "postRegEditFilters": [
+                    RegTexEdit(textures = {"NonReflectiveLightMap": ["ps-t1"]}),
                 ]})
     
     @classmethod
@@ -19245,6 +19847,33 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def kirara6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [],
+                {
+                    "preRegEditFilters": [
+                    RegRemove(remove = {
+                        "head": {*cls.ReflectionHeadRemove, *cls.TexFxRemove}, 
+                        "body": {*cls.ReflectionBodyRemove, *cls.TexFxRemove}, 
+                        "dress": {*cls.ReflectionDressRemove, *cls.TexFxRemove}}),
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t2", cls.ORFixTempReg], **cls.TexFxTempRegRemap},
+                                      "body": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True), 
+                                               **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": KeyRemapData.build([("ps-t0", cls._remapIsDiffuse), cls.NNFixTempReg], keepKeyWithoutRemap = True), 
+                                                "ps-t2": KeyRemapData.build([("ps-t1", cls._remapIsLightMap)], keepKeyWithoutRemap = True), 
+                                                **cls.TexFxTempRegRemap}}),
+                    RegNewVals(vals = {"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename, **cls.TexFxNoNormalValRename5_0}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun},
+                                      "body": {**cls.TexFXTempToRun},
+                                      "dress": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.ORFixTempToRun,
+                                      "body": cls.ORFixTempToRun,
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def kiraraBoots4_8(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [], 
@@ -19279,6 +19908,33 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def kiraraBoots6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ReflectionHeadRemove, *cls.TexFxRemove},
+                                        "body": {*cls.ReflectionBodyRemove, *cls.TexFxRemove},
+                                        "dress": {*cls.ORFixCompleteRemoval, "ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t0": KeyRemapData.build([("tempNorm", cls._remapIsDiffuse), ("ps-t1", cls._remapIsDiffuse)], keepKeyWithoutRemap = True), 
+                                               "ps-t1": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True), 
+                                               "ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True),
+                                               **cls.TexFxTempRegRemap},
+                                      "body": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True),
+                                               **cls.TexFxTempRegRemap},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegTexAdd(textures = {"head": {"tempNorm": ("NormMap", TexCreator(1024, 1024, colour = Colours.NormalMapYellow.value))}}, mustAdd = False),
+                    RegNewVals(vals = {"head": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "body": {cls.ORFixTempReg: IniKeywords.ORFixPath.value, **cls.TexFxNoNormalValRename5_0},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {"tempNorm": ["ps-t0"], **cls.TexFXTempToRun},
+                                      "body": {**cls.TexFXTempToRun}}),
+                    RegRemap(remap = {"head": cls.ORFixTempToRun,
+                                      "body": cls.ORFixTempToRun,
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def klee4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer, 
                 [{"body": ["body", "dress"]}], 
@@ -19286,6 +19942,24 @@ class IniFixBuilderFuncs():
                  "preRegEditFilters": [
                     RegTexEdit(textures = {"GreenLightMap": ["ps-t1"]}),
                     RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}})
+                ]})
+
+    @classmethod
+    def klee6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegTexEdit(textures = {"GreenLightMap": ["ps-t1"]}),
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}}),
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -19297,6 +19971,28 @@ class IniFixBuilderFuncs():
                     RegTexEdit(textures = {"TransparentDiffuse": ["ps-t0"]}),
                     RegRemove(remove = {"head": {"ps-t2"}}),
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
+                ]})
+    
+    @classmethod
+    def kleeBlossomingStarlight6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head"], "body": ["body", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegTexEdit(textures = {"TransparentDiffuse": ["ps-t0"]}),
+                    RegRemove(remove = {"head": {"ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -19357,6 +20053,28 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def lisa6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer,
+                [{"head": ["head"], "body": ["body", "dress"]}],
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value, 
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"},
+                                        "body": {"ps-t3"},
+                                        "dress": {"ps-t2"}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def lisaStudent4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer,
                 [{"body": ["body", "dress"]}],
@@ -19377,12 +20095,62 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def lisaStudent6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer,
+                [{"body": ["body", "dress"]}],
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t0", "ps-t3", *cls.TexFxRemove, *cls.ORFixCompleteRemoval}, 
+                                        "body": {"ps-t0", "ps-t3", *cls.TexFxRemove, *cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap},
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg], **cls.TexFxTempRegRemap}}),
+                    RegNewVals(vals = {"head": {**cls.TexFxNoNormalValRename4_0, **cls.NNFixValRename},
+                                       "body": {**cls.TexFxNoNormalValRename4_0, **cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.TexFXTempToRun, **cls.NNFixTempToRun},
+                                      "body": {**cls.TexFXTempToRun, **cls.NNFixTempToRun}})
+                ],
+                "postRegEditFilters": [
+                    RegRemap(remap = {"body": {"ps-t3": ["ps-t2"]}})
+                ]})
+    
+    @classmethod
     def mona4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
     
     @classmethod
+    def mona6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def monaCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
+    
+    @classmethod
+    def monaCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"postRegEditFilters": [
+                    RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
     
     @classmethod
     def nilou4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19413,9 +20181,9 @@ class IniFixBuilderFuncs():
                 [], 
                 {
                  "preRegEditFilters": [
-                    RegRemove(remove = {"head": {("ps-t0", cls._removeIsNormalMap), cls.ReflectionHeadRemove}, 
-                                        "body": {("ps-t0", cls._removeIsNormalMap), cls.ReflectionDressRemove}, 
-                                        "dress": {("ps-t0", cls._removeIsNormalMap), cls.ReflectionDressRemoves}}),
+                    RegRemove(remove = {"head": {("ps-t0", cls._removeIsNormalMap), *cls.ReflectionHeadRemove}, 
+                                        "body": {("ps-t0", cls._removeIsNormalMap), *cls.ReflectionBodyRemove}, 
+                                        "dress": {("ps-t0", cls._removeIsNormalMap), *cls.ReflectionDressRemove}}),
                     RegRemap(remap = {"head": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True)},
                                         "body": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True)},
                                         "dress": {"ps-t2": KeyRemapData.build([("ps-t2", cls._remapIsLightMap), (cls.ORFixTempReg, cls._remapIsLightMap)], keepKeyWithoutRemap = True)}}),
@@ -19491,6 +20259,26 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def nilouBreeze6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "dress": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "body": {"ps-t3", *cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def ningguang4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, 
                 [],
@@ -19500,8 +20288,48 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def ningguang6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [],
+                {
+                 "preRegEditFilters": [
+                    RegTexEdit({"DarkDiffuse": ["ps-t0"]}),
+                    RegRemove(remove = {"head": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "dress": {"ps-t3", *cls.ORFixCompleteRemoval},
+                                        "body": {"ps-t3", *cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def ningguangOrchid4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
+    
+    @classmethod
+    def ningguangOrchid6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
+                ]})
     
     @classmethod
     def isRaidenBody(cls, ini, line, pattern):
@@ -19521,11 +20349,12 @@ class IniFixBuilderFuncs():
     @classmethod
     def raiden6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer, 
-                [{"body": ["body", "bodydiffuse", "bodylightmap"],
+                [{"body": ["body", "bodydiffuse", "bodylightmap", "bodyreflection"],
                   "dress": ["dress", "dressdiffuse", "dresslightmap"]}], 
                 {
                  "preRegEditOldObj": True,
                  "postIniProcessor": cls.raidenHideOrigBody,
+                 "nameReplace": {"bodyreflection": lambda oldName: oldName.replace("TextureOverride", "ShaderOverride")},
                  "preRegEditFilters": [
                      RegRemove(remove = {"head": {*cls.NNFixRemove},
                                          "body": {*cls.NNFixRemove},
@@ -19533,20 +20362,31 @@ class IniFixBuilderFuncs():
                  ],
                  "postRegEditFilters": [
                     RegRemove(remove = {"body": {"ps-t0", "ps-t1", "ps-t2"},
-                                        "bodydiffuse": {"ps-t1", "ps-t2", "ib", "match_first_index"},
-                                        "bodylightmap": {"ps-t0", "ps-t2", "ib", "match_first_index"},
+                                        "bodydiffuse": {"ps-t1", "ps-t2"},
+                                        "bodylightmap": {"ps-t0", "ps-t2"},
                                         "dress": {"ps-t0", "ps-t1", "ps-t2"},
-                                        "dressdiffuse": {"ps-t1", "ps-t2", "ib", "match_first_index"},
-                                        "dresslightmap": {"ps-t0", "ps-t2", "ib", "match_first_index"}}),
-                    RegNewVals(vals = {"bodydiffuse": {"hash": "9b5d87e0"},
-                                       "dressdiffuse": {"hash": "9b5d87e0"},
-                                       "bodylightmap": {"hash": "452e0279"},
-                                       "dresslightmap": {"hash": "452e0279"}}),
+                                        "dressdiffuse": {"ps-t1", "ps-t2"},
+                                        "dresslightmap": {"ps-t0", "ps-t2"},}),
+                    RegNewVals(vals = {"bodydiffuse": {"hash": "9b5d87e0", "match_first_index": "17769"},
+                                       "dressdiffuse": {"hash": "9b5d87e0", "match_first_index": "52473"},
+                                       "bodylightmap": {"hash": "452e0279", "match_first_index": "17769"},
+                                       "dresslightmap": {"hash": "452e0279", "match_first_index": "52473"},
+                                       "bodyreflection": {"hash": "693d8ed0af54876d"}}),
                     RegRemap({"head": {"ps-t1": ["ps-t1", "temp"]},
                               "bodydiffuse": {"ps-t0": ["this"]},
                               "bodylightmap": {"ps-t1": ["this"]},
                               "dressdiffuse": {"ps-t0": ["this"]},
                               "dresslightmap": {"ps-t1": ["this"]}}),
+                    RegRemove(remove = {"bodydiffuse": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "bodylightmap": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "bodyreflection": {("hash", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "dressdiffuse": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)},
+                                        "dresslightmap": {("this", cls._hasNullIb), ("hash", cls._hasNullIb)}}),
+                    RegRemove(remove = {"bodydiffuse": {"ib"},
+                                        "bodylightmap": {"ib"},
+                                        "dressdiffuse": {"ib"},
+                                        "dresslightmap": {"ib"},
+                                        "bodyreflection": {"ib", "match_first_index"}}),
                     RegNewVals({"head": {"temp": IniKeywords.NNFixPath.value}}),
                     RegRemap({"head": {"temp": ["run"]}})
                 ]})
@@ -19556,8 +20396,54 @@ class IniFixBuilderFuncs():
         return (GIMIObjRegEditFixer, [], {})
     
     @classmethod
+    def rosaria6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "extra": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename},
+                                       "extra": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun},
+                                      "extra": {**cls.NNFixTempToRun}})
+                ]})
+    
+    @classmethod
     def rosariaCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjRegEditFixer, [], {})
+    
+    @classmethod
+    def rosariaCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjRegEditFixer, 
+                [], 
+                {"preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "extra": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename},
+                                       "extra": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun},
+                                      "extra": {**cls.NNFixTempToRun}})
+                ]})
     
     @classmethod
     def shenhe4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19567,6 +20453,34 @@ class IniFixBuilderFuncs():
                  "preRegEditFilters": [
                     RegRemove(remove = {"dress": ["ps-t2"]}),
                     RegRemap(remap = {"dress": {"ps-t3": ["ps-t2"]}})
+                ]})
+    
+    @classmethod
+    def shenhe6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head"], "body": ["body"], "dress": ["dress", "extra"]}], 
+                {
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"dress": ["ps-t2"]}),
+                    RegRemap(remap = {"dress": {"ps-t3": ["ps-t2"]}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval},
+                                        "dress": {*cls.ORFixCompleteRemoval},
+                                        "body": {*cls.ORFixCompleteRemoval},
+                                        "extra": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "extra": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress":  {**cls.NNFixValRename},
+                                       "extra": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun},
+                                      "extra": {**cls.NNFixTempToRun}})
                 ]})
     
     @classmethod
@@ -19584,6 +20498,28 @@ class IniFixBuilderFuncs():
                  "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
                  "postRegEditFilters": [
                      RegNewVals(vals = {"head": {"ib": "null"}})
+                 ]})
+    
+    @classmethod
+    def shenheFrostFlower6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "head", "head"], "body": ["head", "body", "extra"], "dress": ["dress", "dress", "dress"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                 "postRegEditFilters": [
+                     RegNewVals(vals = {"head": {"ib": "null"}}),
+                     RegRemove(remove = {"head": cls.ORFixCompleteRemoval,
+                                        "body": cls.ORFixCompleteRemoval,
+                                        "dress": cls.ORFixCompleteRemoval}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "dress": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename},
+                                       "dress": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun},
+                                      "dress": {**cls.NNFixTempToRun}})
                  ]})
     
     @classmethod
@@ -19628,10 +20564,49 @@ class IniFixBuilderFuncs():
                 ]})
     
     @classmethod
+    def xianglingCheer6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer,
+                [{"head": ["head", "dress"], "body": ["body"]}], 
+                {
+                 "preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t0", *cls.ReflectionHeadRemove}, 
+                                        "body": {"ps-t0", *cls.ReflectionBodyRemove}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t0"], "ps-t2": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ],
+                "postRegEditFilters": [
+                    RegNewVals(vals = {"head": {IniKeywords.Ib.value: "null"}})
+                ]})
+    
+    @classmethod
     def xingqiu4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
         return (GIMIObjSplitFixer, 
                 [{"head": ["head", "dress"]}], 
                 {
+                 "postRegEditFilters": [
+                    RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}})
+                ]})
+    
+    @classmethod
+    def xingqiu6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjSplitFixer, 
+                [{"head": ["head", "dress"], "body": ["body"]}], 
+                {"preRegEditOldObj": True,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval}, 
+                                        "body": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ],
                  "postRegEditFilters": [
                     RegRemap(remap = {"head": {"ps-t2": ["ps-t3"]}})
                 ]})
@@ -19646,7 +20621,27 @@ class IniFixBuilderFuncs():
                     RegRemove(remove = {"head": {"ps-t2"}}),
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
                 ]})
-
+    
+    @classmethod
+    def xingqiuBamboo6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
+        return (GIMIObjMergeFixer, 
+                [{"head": ["head", "dress"], "body": ["body", "body"]}], 
+                {
+                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
+                 "preRegEditFilters": [
+                    RegRemove(remove = {"head": {"ps-t2"}}),
+                    RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}})
+                ],
+                "postRegEditFilters": [
+                    RegRemove(remove = {"head": {*cls.ORFixCompleteRemoval}, 
+                                        "body": {*cls.ORFixCompleteRemoval}}),
+                    RegRemap(remap = {"head": {"ps-t1": ["ps-t1", cls.NNFixTempReg]},
+                                      "body": {"ps-t1": ["ps-t1", cls.NNFixTempReg]}}),
+                    RegNewVals(vals = {"head": {**cls.NNFixValRename},
+                                       "body": {**cls.NNFixValRename}}),
+                    RegRemap(remap = {"head": {**cls.NNFixTempToRun},
+                                      "body": {**cls.NNFixTempToRun}})
+                ]})
 
 IniFixBuilderData = {
     4.0: {
@@ -19750,7 +20745,48 @@ IniFixBuilderData = {
         ModTypeNames.ShenheFrostFlower.value: IniFixBuilderFuncs.shenheFrostFlower5_7
     },
 
-    6.1: {ModTypeNames.Raiden.value: IniFixBuilderFuncs.raiden6_1}
+    6.1: {
+        ModTypeNames.Amber.value: IniFixBuilderFuncs.amber6_1,
+        ModTypeNames.AmberCN.value: IniFixBuilderFuncs.amberCN6_1,
+        ModTypeNames.Ayaka.value: IniFixBuilderFuncs.ayaka6_1,
+        ModTypeNames.AyakaSpringbloom.value: IniFixBuilderFuncs.ayakaSpringbloom6_1,
+        ModTypeNames.Barbara.value: IniFixBuilderFuncs.barbara6_1,
+        ModTypeNames.BarbaraSummertime.value: IniFixBuilderFuncs.barbaraSummertime6_1,
+        ModTypeNames.CherryHuTao.value: IniFixBuilderFuncs.cherryHuTao6_1,
+        ModTypeNames.Diluc.value: IniFixBuilderFuncs.diluc6_1,
+        ModTypeNames.DilucFlamme.value: IniFixBuilderFuncs.dilucFlamme6_1,
+        ModTypeNames.Fischl.value: IniFixBuilderFuncs.fischl6_1,
+        ModTypeNames.FischlHighness.value: IniFixBuilderFuncs.fischlHighness6_1,
+        ModTypeNames.GanyuTwilight.value: IniFixBuilderFuncs.ganyuTwilight6_1,
+        ModTypeNames.Ganyu.value: IniFixBuilderFuncs.ganyu6_1,
+        ModTypeNames.HuTao.value: IniFixBuilderFuncs.hutao6_1,
+        ModTypeNames.Jean.value: IniFixBuilderFuncs.jean6_1,
+        ModTypeNames.JeanCN.value: IniFixBuilderFuncs.jeanCN6_1,
+        ModTypeNames.JeanSea.value: IniFixBuilderFuncs.jeanSea6_1,
+        ModTypeNames.KaeyaSailwind.value: IniFixBuilderFuncs.kaeyaSailwind6_1,
+        ModTypeNames.Kaeya.value: IniFixBuilderFuncs.kaeya6_1,
+        ModTypeNames.Keqing.value: IniFixBuilderFuncs.keqing6_1,
+        ModTypeNames.KeqingOpulent.value: IniFixBuilderFuncs.keqingOpulent6_1,
+        ModTypeNames.KiraraBoots.value: IniFixBuilderFuncs.kiraraBoots6_1,
+        ModTypeNames.Kirara.value: IniFixBuilderFuncs.kirara6_1,
+        ModTypeNames.Klee.value: IniFixBuilderFuncs.klee6_1,
+        ModTypeNames.KleeBlossomingStarlight.value: IniFixBuilderFuncs.kleeBlossomingStarlight6_1,
+        ModTypeNames.Lisa.value: IniFixBuilderFuncs.lisa6_1,
+        ModTypeNames.LisaStudent.value: IniFixBuilderFuncs.lisaStudent6_1,
+        ModTypeNames.Mona.value: IniFixBuilderFuncs.mona6_1,
+        ModTypeNames.MonaCN.value: IniFixBuilderFuncs.monaCN6_1,
+        ModTypeNames.NilouBreeze.value: IniFixBuilderFuncs.nilouBreeze6_1,
+        ModTypeNames.Ningguang.value: IniFixBuilderFuncs.ningguang6_1,
+        ModTypeNames.NingguangOrchid.value: IniFixBuilderFuncs.ningguangOrchid6_1,
+        ModTypeNames.Rosaria.value: IniFixBuilderFuncs.rosaria6_1,
+        ModTypeNames.RosariaCN.value: IniFixBuilderFuncs.rosariaCN6_1,
+        ModTypeNames.Shenhe.value: IniFixBuilderFuncs.shenhe6_1,
+        ModTypeNames.ShenheFrostFlower.value: IniFixBuilderFuncs.shenheFrostFlower6_1,
+        ModTypeNames.XianglingCheer.value: IniFixBuilderFuncs.xianglingCheer6_1,
+        ModTypeNames.Xingqiu.value: IniFixBuilderFuncs.xingqiu6_1,
+        ModTypeNames.XingqiuBamboo.value: IniFixBuilderFuncs.xingqiuBamboo6_1,
+        ModTypeNames.Raiden.value: IniFixBuilderFuncs.raiden6_1
+    }
 }
 
 

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_hideOrig/multiFix/oldVers/AmberCN.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_hideOrig/multiFix/oldVers/AmberCN.ini
@@ -36,6 +36,7 @@ ps-t0 = ResourceAmberCNBodyDiffuse
 ps-t1 = ResourceAmberCNBodyLightMap
 ps-t2 = ResourceAmberCNBodyMetalMap
 ps-t3 = ResourceAmberCNBodyShadowRamp
+run = CommandList\global\ORFix\NNFix
 drawindexed = auto
 
 [ResourceAmberCNAmberRemapBlend]

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Jean/SmolJean/SmolJean.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Jean/SmolJean/SmolJean.ini
@@ -35,6 +35,7 @@ match_first_index = 7779
 ib = ResourceJeanSeaBodyIB
 ps-t0 = ResourceJeanSeaBodyDiffuse
 ps-t1 = ResourceJeanSeaBodyLightMap
+run = CommandList\global\ORFix\NNFix
 
 [ResourceJeanJeanCNRemapBlend]
 type = Buffer
@@ -55,6 +56,7 @@ match_first_index = 7662
 ib = ResourceJeanSeaBodyIB
 ps-t0 = ResourceJeanSeaBodyDiffuse
 ps-t1 = ResourceJeanBodyShadeLightMapJeanSeaRemapTex0
+run = CommandList\global\ORFix\NNFix
 
 [TextureOverrideJeanDressJeanSeaRemapFix]
 hash = 69c0c24e
@@ -62,6 +64,7 @@ match_first_index = 52542
 ib = null
 ps-t0 = ResourceJeanSeaBodyDiffuse
 ps-t1 = ResourceJeanSeaBodyLightMap
+run = CommandList\global\ORFix\NNFix
 
 [ResourceJeanJeanSeaRemapBlend]
 type = Buffer

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Jean/merged.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Jean/merged.ini
@@ -71,12 +71,14 @@ if $swapvar == 0
 	ib = ResourceJeanSeaBodyIB
 	ps-t0 = ResourceJeanSeaBodyDiffuse
 	ps-t1 = ResourceJeanSeaBodyLightMap
+	run = CommandList\global\ORFix\NNFix
 else if $swapvar == 1
 	hash = aad861e0
 	match_first_index = 7779
 	ib = ResourceJeanSeaBodyIB
 	ps-t0 = ResourceJeanSeaBodyDiffuse
 	ps-t1 = ResourceJeanSeaBodyLightMap
+	run = CommandList\global\ORFix\NNFix
 endif
 
 [ResourceJeanJeanCNRemapBlend.0]
@@ -110,12 +112,14 @@ if $swapvar == 0
 	ib = ResourceJeanSeaBodyIB
 	ps-t0 = ResourceJeanSeaBodyDiffuse
 	ps-t1 = ResourceJeanBodyShadeLightMapJeanSeaRemapTex0
+	run = CommandList\global\ORFix\NNFix
 else if $swapvar == 1
 	hash = 69c0c24e
 	match_first_index = 7662
 	ib = ResourceJeanSeaBodyIB
 	ps-t0 = ResourceJeanSeaBodyDiffuse
 	ps-t1 = ResourceJeanBodyShadeLightMapJeanSeaRemapTex0
+	run = CommandList\global\ORFix\NNFix
 endif
 
 [TextureOverrideJeanDressJeanSeaRemapFix]
@@ -125,12 +129,14 @@ if $swapvar == 0
 	ib = null
 	ps-t0 = ResourceJeanSeaBodyDiffuse
 	ps-t1 = ResourceJeanSeaBodyLightMap
+	run = CommandList\global\ORFix\NNFix
 else if $swapvar == 1
 	hash = 69c0c24e
 	match_first_index = 52542
 	ib = null
 	ps-t0 = ResourceJeanSeaBodyDiffuse
 	ps-t1 = ResourceJeanSeaBodyLightMap
+	run = CommandList\global\ORFix\NNFix
 endif
 
 [ResourceJeanJeanSeaRemapBlend.0]

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/BestGurl.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/BestGurl.ini
@@ -94,24 +94,6 @@ else if $swapvar == 1
 	draw = 21916,0
 endif
 
-[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
-hash = 7c6fc8c3
-match_first_index = 19623
-run = CommandListKeqingBodyKeqingOpulentRemapFix
-
-[CommandListKeqingBodyKeqingOpulentRemapFix]
-if $swapvar == 0
-	ib = ResourceKeqingBodyIB.0
-	ps-t0 = ResourceKeqingBodyDiffuse.0
-	ps-t1 = ResourceKeqingBodyLightMap.0
-	ps-t2 = ResourceKeqingBodyMetalMap.0
-	ps-t3 = ResourceKeqingBodyShadowRamp.0
-else if $swapvar == 1
-	ib = ResourceKeqingBodyIB.3
-	ps-t0 = ResourceKeqingBodyDiffuse.3
-	ps-t1 = ResourceKeqingBodyLightMap.3
-endif
-
 [TextureOverrideKeqingHeadKeqingOpulentRemapFix]
 hash = 7c6fc8c3
 match_first_index = 0
@@ -124,10 +106,32 @@ if $swapvar == 0
 	ps-t1 = ResourceKeqingDressLightMap.0
 	ps-t2 = ResourceKeqingDressMetalMap.0
 	ps-t3 = ResourceKeqingDressShadowRamp.0
+	run = CommandList\global\ORFix\NNFix
 else if $swapvar == 1
 	ib = ResourceKeqingDressIB.3
 	ps-t0 = ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex1
 	ps-t1 = ResourceKeqingDressLightMap.3
+	run = CommandList\global\ORFix\NNFix
+endif
+
+[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
+hash = 7c6fc8c3
+match_first_index = 19623
+run = CommandListKeqingBodyKeqingOpulentRemapFix
+
+[CommandListKeqingBodyKeqingOpulentRemapFix]
+if $swapvar == 0
+	ib = ResourceKeqingBodyIB.0
+	ps-t0 = ResourceKeqingBodyDiffuse.0
+	ps-t1 = ResourceKeqingBodyLightMap.0
+	ps-t2 = ResourceKeqingBodyMetalMap.0
+	ps-t3 = ResourceKeqingBodyShadowRamp.0
+	run = CommandList\global\ORFix\NNFix
+else if $swapvar == 1
+	ib = ResourceKeqingBodyIB.3
+	ps-t0 = ResourceKeqingBodyDiffuse.3
+	ps-t1 = ResourceKeqingBodyLightMap.3
+	run = CommandList\global\ORFix\NNFix
 endif
 
 [ResourceKeqingKeqingOpulentRemapBlend.0]

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/BestGurlRemapFix1.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/BestGurlRemapFix1.ini
@@ -116,24 +116,6 @@ else if $swapvar == 1
 	draw = 21916,0
 endif
 
-[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
-hash = 7c6fc8c3
-match_first_index = 19623
-run = CommandListKeqingBodyKeqingOpulentRemapFix
-
-[CommandListKeqingBodyKeqingOpulentRemapFix]
-if $swapvar == 0
-	ib = ResourceKeqingBodyIB.0
-	ps-t0 = ResourceKeqingBodyDiffuse.0
-	ps-t1 = ResourceKeqingBodyLightMap.0
-	ps-t2 = ResourceKeqingBodyMetalMap.0
-	ps-t3 = ResourceKeqingBodyShadowRamp.0
-else if $swapvar == 1
-	ib = ResourceKeqingBodyIB.3
-	ps-t0 = ResourceKeqingBodyDiffuse.3
-	ps-t1 = ResourceKeqingBodyLightMap.3
-endif
-
 [ResourceKeqingKeqingOpulentRemapBlend.0]
 type = Buffer
 stride = 32

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/Cutie.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/Cutie.ini
@@ -112,24 +112,6 @@ else if $swapvar == 1
 	draw = 21916,0
 endif
 
-[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
-hash = 7c6fc8c3
-match_first_index = 19623
-run = CommandListKeqingBodyKeqingOpulentRemapFix
-
-[CommandListKeqingBodyKeqingOpulentRemapFix]
-if $swapvar == 0
-	ib = ResourceKeqingBodyIB.0
-	ps-t0 = ResourceKeqingBodyDiffuse.0
-	ps-t1 = ResourceKeqingBodyLightMap.0
-	ps-t2 = ResourceKeqingBodyMetalMap.0
-	ps-t3 = ResourceKeqingBodyShadowRamp.0
-else if $swapvar == 1
-	ib = ResourceKeqingBodyIB.3
-	ps-t0 = ResourceKeqingBodyDiffuse.3
-	ps-t1 = ResourceKeqingBodyLightMap.3
-endif
-
 [TextureOverrideKeqingHeadKeqingOpulentRemapFix]
 hash = 7c6fc8c3
 match_first_index = 0
@@ -142,10 +124,32 @@ if $swapvar == 0
 	ps-t1 = ResourceKeqingDressLightMap.0
 	ps-t2 = ResourceKeqingDressMetalMap.0
 	ps-t3 = ResourceKeqingDressShadowRamp.0
+	run = CommandList\global\ORFix\NNFix
 else if $swapvar == 1
 	ib = ResourceKeqingDressIB.3
 	ps-t0 = ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex1
 	ps-t1 = ResourceKeqingDressLightMap.3
+	run = CommandList\global\ORFix\NNFix
+endif
+
+[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
+hash = 7c6fc8c3
+match_first_index = 19623
+run = CommandListKeqingBodyKeqingOpulentRemapFix
+
+[CommandListKeqingBodyKeqingOpulentRemapFix]
+if $swapvar == 0
+	ib = ResourceKeqingBodyIB.0
+	ps-t0 = ResourceKeqingBodyDiffuse.0
+	ps-t1 = ResourceKeqingBodyLightMap.0
+	ps-t2 = ResourceKeqingBodyMetalMap.0
+	ps-t3 = ResourceKeqingBodyShadowRamp.0
+	run = CommandList\global\ORFix\NNFix
+else if $swapvar == 1
+	ib = ResourceKeqingBodyIB.3
+	ps-t0 = ResourceKeqingBodyDiffuse.3
+	ps-t1 = ResourceKeqingBodyLightMap.3
+	run = CommandList\global\ORFix\NNFix
 endif
 
 [ResourceKeqingKeqingOpulentRemapBlend.0]

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/CutieRemapFix1.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_fullFix_someFix/multiFix/select/Kequeen/IniOrJoJ/CutieRemapFix1.ini
@@ -134,24 +134,6 @@ else if $swapvar == 1
 	draw = 21916,0
 endif
 
-[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
-hash = 7c6fc8c3
-match_first_index = 19623
-run = CommandListKeqingBodyKeqingOpulentRemapFix
-
-[CommandListKeqingBodyKeqingOpulentRemapFix]
-if $swapvar == 0
-	ib = ResourceKeqingBodyIB.0
-	ps-t0 = ResourceKeqingBodyDiffuse.0
-	ps-t1 = ResourceKeqingBodyLightMap.0
-	ps-t2 = ResourceKeqingBodyMetalMap.0
-	ps-t3 = ResourceKeqingBodyShadowRamp.0
-else if $swapvar == 1
-	ib = ResourceKeqingBodyIB.3
-	ps-t0 = ResourceKeqingBodyDiffuse.3
-	ps-t1 = ResourceKeqingBodyLightMap.3
-endif
-
 [TextureOverrideKeqingHeadKeqingOpulentRemapFix]
 hash = 7c6fc8c3
 match_first_index = 0
@@ -164,10 +146,12 @@ if $swapvar == 0
 	ps-t1 = ResourceKeqingHeadLightMap.0
 	ps-t2 = ResourceKeqingHeadMetalMap.0
 	ps-t3 = ResourceKeqingHeadShadowRamp.0
+	run = CommandList\global\ORFix\NNFix
 else if $swapvar == 1
 	ib = ResourceKeqingHeadIB.3
 	ps-t0 = ResourceKeqingHeadOpaqueHeadDiffuseKeqingOpulentRemapTex1
 	ps-t1 = ResourceKeqingHeadLightMap.3
+	run = CommandList\global\ORFix\NNFix
 endif
 
 [ResourceKeqingKeqingOpulentRemapBlend.0]

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_iniPath_forcedType/overrideFix/KiraraAlt.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_iniPath_forcedType/overrideFix/KiraraAlt.ini
@@ -154,7 +154,7 @@ ib = ResourceKiraraBodyIB
 ps-t0 = ResourceKiraraBodyNormalMap
 ps-t1 = ResourceKiraraBodyDiffuse
 ps-t2 = ResourceKiraraBodyLightMap
-run = CommandList\global\ORFix\ORFix
+run = CommandList\global\ORFix\NNFix
 
 [TextureOverrideKiraraDressRosariaCNRemapFix]
 hash = bdca273e
@@ -163,7 +163,7 @@ ib = null
 ps-t0 = ResourceKiraraDressNormalMap
 ps-t1 = ResourceKiraraDressDiffuse
 ps-t2 = ResourceKiraraDressLightMap
-run = CommandList\global\ORFix\ORFix
+run = CommandList\global\ORFix\NNFix
 
 [TextureOverrideKiraraHeadRosariaCNRemapFix]
 hash = bdca273e
@@ -172,7 +172,7 @@ ib = ResourceKiraraHeadIB
 ps-t0 = ResourceKiraraHeadNormalMap
 ps-t1 = ResourceKiraraHeadDiffuse
 ps-t2 = ResourceKiraraHeadLightMap
-run = CommandList\global\ORFix\ORFix
+run = CommandList\global\ORFix\NNFix
 
 [ResourceKiraraRosariaCNRemapBlend]
 type = Buffer

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_iniPath_hideOrig/changeVersionKeqing.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_iniPath_hideOrig/changeVersionKeqing.ini
@@ -94,24 +94,6 @@ else if $swapvar == 1
 	draw = 21916,0
 endif
 
-[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
-hash = 7c6fc8c3
-match_first_index = 19623
-run = CommandListKeqingBodyKeqingOpulentRemapFix
-
-[CommandListKeqingBodyKeqingOpulentRemapFix]
-if $swapvar == 0
-	ib = ResourceKeqingBodyIB.0
-	ps-t0 = ResourceKeqingBodyDiffuse.0
-	ps-t1 = ResourceKeqingBodyLightMap.0
-	ps-t2 = ResourceKeqingBodyMetalMap.0
-	ps-t3 = ResourceKeqingBodyShadowRamp.0
-else if $swapvar == 1
-	ib = ResourceKeqingBodyIB.3
-	ps-t0 = ResourceKeqingBodyDiffuse.3
-	ps-t1 = ResourceKeqingBodyLightMap.3
-endif
-
 [TextureOverrideKeqingHeadKeqingOpulentRemapFix]
 hash = 7c6fc8c3
 match_first_index = 0
@@ -124,10 +106,32 @@ if $swapvar == 0
 	ps-t1 = ResourceKeqingDressLightMap.0
 	ps-t2 = ResourceKeqingDressMetalMap.0
 	ps-t3 = ResourceKeqingDressShadowRamp.0
+	run = CommandList\global\ORFix\NNFix
 else if $swapvar == 1
 	ib = ResourceKeqingDressIB.3
 	ps-t0 = ResourceKeqingDressOpaqueDressDiffuseKeqingOpulentRemapTex1
 	ps-t1 = ResourceKeqingDressLightMap.3
+	run = CommandList\global\ORFix\NNFix
+endif
+
+[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
+hash = 7c6fc8c3
+match_first_index = 19623
+run = CommandListKeqingBodyKeqingOpulentRemapFix
+
+[CommandListKeqingBodyKeqingOpulentRemapFix]
+if $swapvar == 0
+	ib = ResourceKeqingBodyIB.0
+	ps-t0 = ResourceKeqingBodyDiffuse.0
+	ps-t1 = ResourceKeqingBodyLightMap.0
+	ps-t2 = ResourceKeqingBodyMetalMap.0
+	ps-t3 = ResourceKeqingBodyShadowRamp.0
+	run = CommandList\global\ORFix\NNFix
+else if $swapvar == 1
+	ib = ResourceKeqingBodyIB.3
+	ps-t0 = ResourceKeqingBodyDiffuse.3
+	ps-t1 = ResourceKeqingBodyLightMap.3
+	run = CommandList\global\ORFix\NNFix
 endif
 
 [ResourceKeqingKeqingOpulentRemapBlend.0]

--- a/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_iniPath_hideOrig/changeVersionKeqingRemapFix1.ini
+++ b/Testing/Integration Tester/IntegrationTester/Tests/APIDocsTests/expected_iniPath_hideOrig/changeVersionKeqingRemapFix1.ini
@@ -116,24 +116,6 @@ else if $swapvar == 1
 	draw = 21916,0
 endif
 
-[TextureOverrideKeqingBodyKeqingOpulentRemapFix]
-hash = 7c6fc8c3
-match_first_index = 19623
-run = CommandListKeqingBodyKeqingOpulentRemapFix
-
-[CommandListKeqingBodyKeqingOpulentRemapFix]
-if $swapvar == 0
-	ib = ResourceKeqingBodyIB.0
-	ps-t0 = ResourceKeqingBodyDiffuse.0
-	ps-t1 = ResourceKeqingBodyLightMap.0
-	ps-t2 = ResourceKeqingBodyMetalMap.0
-	ps-t3 = ResourceKeqingBodyShadowRamp.0
-else if $swapvar == 1
-	ib = ResourceKeqingBodyIB.3
-	ps-t0 = ResourceKeqingBodyDiffuse.3
-	ps-t1 = ResourceKeqingBodyLightMap.3
-endif
-
 [ResourceKeqingKeqingOpulentRemapBlend.0]
 type = Buffer
 stride = 32

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/RemapFixLog.txt
@@ -6,23 +6,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -94,7 +94,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -102,27 +102,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -170,20 +170,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -201,7 +201,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -209,27 +209,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/RemapFixLog.txt
@@ -29,7 +29,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -37,27 +37,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -92,7 +92,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -100,27 +100,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RemapFixLog.txt
@@ -56,23 +56,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -144,7 +144,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -152,27 +152,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -205,20 +205,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -237,7 +237,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -245,27 +245,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsNoBackups/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsNoBackups/Logs/RemapFixLog.txt
@@ -56,23 +56,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -144,7 +144,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -152,27 +152,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -221,20 +221,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -253,7 +253,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -261,27 +261,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/RemapFixLog.txt
@@ -29,7 +29,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -37,27 +37,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -88,7 +88,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -96,27 +96,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/requirements.txt
+++ b/Testing/Integration Tester/requirements.txt
@@ -1,4 +1,4 @@
 directory-tree==0.0.4
 ordered-set==4.1.0
-pillow==11.0.0
+pillow>=11.0.0
 packaging==25.0

--- a/Testing/Unit Tester/UnitTester/Tests/test_IfContentPart.py
+++ b/Testing/Unit Tester/UnitTester/Tests/test_IfContentPart.py
@@ -274,11 +274,11 @@ class IfContentPartTest(BaseUnitTest):
         depth = 1
         tests = [
             [{}, ("a", lambda valData: True), {}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("a", lambda valData: valData[1] == "aVal"), {"a": [(1, "a2Val")], "b": [(0, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("a", lambda valData: len(valData[1]) > 0), {"b": [(0, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("a", lambda valData: False), {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("c", lambda valData: True), {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("c", lambda valData: False), {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "d": []}],
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("a", lambda valData, part: valData[1] == "aVal"), {"a": [(1, "a2Val")], "b": [(0, "bVal")], "c": [], "d": []}],
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("a", lambda valData, part: len(valData[1]) > 0), {"b": [(0, "bVal")], "c": [], "d": []}],
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("a", lambda valData, part: False), {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}],
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("c", lambda valData, part: True), {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "d": []}],
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, ("c", lambda valData, part: False), {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "d": []}],
             [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, "x", {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}]
         ]
 
@@ -295,22 +295,22 @@ class IfContentPartTest(BaseUnitTest):
     def test_differentKeysAndChecks_keysRemoved(self):
         depth = 1
         tests = [
-            [{}, {("a", lambda valData: True)}, {}],
+            [{}, {("a", lambda valData, part: True)}, {}],
             [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, set(), 
              {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData: valData[1] == "aVal")}, 
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData, part: valData[1] == "aVal")}, 
              {"a": [(1, "a2Val")], "b": [(0, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData: valData[1] == "aVal"), ("a", lambda valData: valData[1] == "a2Val")}, 
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData, part: valData[1] == "aVal"), ("a", lambda valData, part   : valData[1] == "a2Val")}, 
              {"b": [(0, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData: valData[1] == "aVal"), "a"}, 
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData, part: valData[1] == "aVal"), "a"}, 
              {"b": [(0, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData: valData[1] == "aVal"), "b"}, 
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData, part: valData[1] == "aVal"), "b"}, 
              {"a": [(0, "a2Val")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData: False)}, 
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("a", lambda valData, part: False)}, 
              {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("c", lambda valData: True), ("a", lambda valData: False)}, {
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("c", lambda valData, part: True), ("a", lambda valData, part: False)}, {
                 "a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "d": []}],
-            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("c", lambda valData: False)}, 
+            [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {("c", lambda valData, part: False)}, 
              {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "d": []}],
             [{"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}, {"x", "y", "z"}, 
              {"a": [(0, "aVal"), (2, "a2Val")], "b": [(1, "bVal")], "c": [], "d": []}]

--- a/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
+++ b/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
@@ -4,7 +4,7 @@ from ..softwareStats.SoftwareContributor import SoftwareContributor
 
 Title = "Anime Game Remap"
 ShortTitle = "AG Remap"
-APIVersion = "4.5.5"
+APIVersion = "4.6.0"
 
 Authors = {
     "Albert": SoftwareContributor("Albert Gold", discName = "albertgold", oldDisName = "Albert Gold#2696"),


### PR DESCRIPTION
https://github.com/nhok0169/Anime-Game-Remap/issues/199

<br>

- Most characters have their textures swapped. NNFix/ORFix should cover most cases

- For Raiden: 
   - Do not set textures if the corresponding `ib` (index buffer) is null
   - Due to `NNFix` not covering the unique case for Raiden, we need to custom copy the texture using a `ShaderOverride` to correctly set the reflection
- Fixed renaming of commands that do not have a the mod object as a substring within the command name