### PR TITLE
Remove extra new line when removing ini boilerplate

### DIFF
--- a/Anime Game Remap (for all users)/api/pyproject.toml
+++ b/Anime Game Remap (for all users)/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "4.6.2"
+version = "4.6.3"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniRemovers/IniRemover.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniRemovers/IniRemover.py
@@ -42,7 +42,7 @@ class IniRemover(BaseIniRemover):
         The .ini file to remove the fix from
     """
 
-    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*)|(; {IniBoilerPlate.DefaultHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*)")
+    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*(\\n)?)|(; {IniBoilerPlate.DefaultHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*(\\n)?)")
     _removalPattern = re.compile(r"^\s*\[" + f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value + r"|Fix|Tex).*\]")
     _sectionRemovalPattern = re.compile(f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value +  r"|Fix|Tex).*")
     _remapTexRemovalPattern = re.compile(IniKeywords.Resource.value + f".*" + IniKeywords.RemapTex.value + r".*")

--- a/Anime Game Remap (for all users)/apiMirror/pyproject.toml
+++ b/Anime Game Remap (for all users)/apiMirror/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AnimeGameRemap"
-version = "4.6.2"
+version = "4.6.3"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	"FixRaidenBoss2==4.6.2"
+	"FixRaidenBoss2==4.6.3"
 ]
 
 [project.urls]

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, November 15, 2025 09:35:27.748 AM UTC
-# Run Hash: ad1e55fe-b9c2-4df8-9f2a-6f40f5415ede
+# Datetime Ran: Sunday, February 15, 2026 01:10:55.805 PM UTC
+# Run Hash: e84ed157-9c5f-4f76-aeb3-6b027024d514
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.6.2
+# Version: 4.6.3
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, November 15, 2025 09:35:27.748 AM UTC
-# Build Hash: 2a6daf99-f482-4138-ae1d-5489469a84a8
+# Datetime Compiled: Sunday, February 15, 2026 01:10:55.805 PM UTC
+# Build Hash: a32bdf93-bb76-4095-b8f1-b09bcf8bfdab
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, November 15, 2025 09:35:27.748 AM UTC
-# Run Hash: ad1e55fe-b9c2-4df8-9f2a-6f40f5415ede
+# Datetime Ran: Sunday, February 15, 2026 01:10:55.805 PM UTC
+# Run Hash: e84ed157-9c5f-4f76-aeb3-6b027024d514
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.6.2
+# Version: 4.6.3
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, November 15, 2025 09:35:27.748 AM UTC
-# Build Hash: 2a6daf99-f482-4138-ae1d-5489469a84a8
+# Datetime Compiled: Sunday, February 15, 2026 01:10:55.805 PM UTC
+# Build Hash: a32bdf93-bb76-4095-b8f1-b09bcf8bfdab
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Saturday, November 15, 2025 09:35:27.270 AM UTC
-# Run Hash: 37a756be-7940-44f1-bbac-5ca2ad2ea608
+# Datetime Ran: Sunday, February 15, 2026 01:10:55.405 PM UTC
+# Run Hash: 809f4290-2849-4fdd-99dc-3c4d6b804e14
 # 
 # *******************************
 # ================
@@ -33,10 +33,10 @@
 #
 # ***** AG Remap Script Stats *****
 #
-# Version: 4.6.2
+# Version: 4.6.3
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Saturday, November 15, 2025 09:35:27.270 AM UTC
-# Build Hash: 6199f43e-7ad3-4141-934d-b3540bd2c233
+# Datetime Compiled: Sunday, February 15, 2026 01:10:55.405 PM UTC
+# Build Hash: 61be42d7-22ca-4bc6-9448-d9103963415c
 #
 # *********************************
 #
@@ -9016,7 +9016,7 @@ class IniRemover(BaseIniRemover):
         The .ini file to remove the fix from
     """
 
-    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*)|(; {IniBoilerPlate.DefaultHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*)")
+    _fixRemovalPattern = re.compile(f"(; {IniBoilerPlate.OldHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.OldHeading.value.close()[:-2]}(-)*(\\n)?)|(; {IniBoilerPlate.DefaultHeading.value.open()}" + r"((.|\n)*?);" + f" {IniBoilerPlate.DefaultHeading.value.close()[:-2]}(-)*(\\n)?)")
     _removalPattern = re.compile(r"^\s*\[" + f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value + r"|Fix|Tex).*\]")
     _sectionRemovalPattern = re.compile(f".*{IniKeywords.Remap.value}(" + IniKeywords.Blend.value + "|" + IniKeywords.Position.value +  r"|Fix|Tex).*")
     _remapTexRemovalPattern = re.compile(IniKeywords.Resource.value + f".*" + IniKeywords.RemapTex.value + r".*")

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/RemapFixLog.txt
@@ -6,23 +6,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -94,7 +94,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -102,27 +102,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -170,20 +170,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -201,7 +201,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -209,27 +209,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/RemapFixLog.txt
@@ -29,7 +29,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -37,27 +37,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -92,7 +92,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -100,27 +100,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RemapFixLog.txt
@@ -56,23 +56,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -144,7 +144,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -152,27 +152,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -205,20 +205,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -237,7 +237,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -245,27 +245,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsNoBackups/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsNoBackups/Logs/RemapFixLog.txt
@@ -56,23 +56,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -144,7 +144,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -152,27 +152,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -221,20 +221,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -253,7 +253,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -261,27 +261,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/RemapFixLog.txt
@@ -29,7 +29,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -37,27 +37,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -88,7 +88,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -96,27 +96,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
+++ b/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
@@ -4,7 +4,7 @@ from ..softwareStats.SoftwareContributor import SoftwareContributor
 
 Title = "Anime Game Remap"
 ShortTitle = "AG Remap"
-APIVersion = "4.6.2"
+APIVersion = "4.6.3"
 
 Authors = {
     "Albert": SoftwareContributor("Albert Gold", discName = "albertgold", oldDisName = "Albert Gold#2696"),


### PR DESCRIPTION
- Without removing the extra newline from the end of the boilerplate during .ini removal, an extra newline will be added every time the fix is removed instead of preserving the original content of the .ini file