### PR TITLE
Fix TexFx texture rendering

### DIFF
--- a/Anime Game Remap (for all users)/api/pyproject.toml
+++ b/Anime Game Remap (for all users)/api/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "FixRaidenBoss2"
-version = "4.6.3"
+version = "4.6.4"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}

--- a/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
+++ b/Anime Game Remap (for all users)/api/src/FixRaidenBoss2/data/IniFixBuilderData.py
@@ -160,7 +160,7 @@ class IniFixBuilderFuncs():
                                                            "body": cls.IbDrawIndexedRename}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def amber6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -177,7 +177,7 @@ class IniFixBuilderFuncs():
                                                           "body": cls.NNFixTempToRun}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def amberCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -192,7 +192,7 @@ class IniFixBuilderFuncs():
                                                            "body": cls.IbDrawIndexedRename}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def amberCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -209,7 +209,7 @@ class IniFixBuilderFuncs():
                                                           "body": cls.NNFixTempToRun}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ayaka4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -278,7 +278,7 @@ class IniFixBuilderFuncs():
                                          "body": cls.IbTempToDrawIndexed,
                                          "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ayaka5_7(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -303,7 +303,7 @@ class IniFixBuilderFuncs():
                                          "body": cls.IbTempToDrawIndexed,
                                          "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ayaka6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -327,7 +327,7 @@ class IniFixBuilderFuncs():
                                          "body": {**cls.ORFixTempToRun, **cls.IbTempToDrawIndexed},
                                          "dress": {**cls.NNFixTempToRun, **cls.IbTempToDrawIndexed}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def ayakaSpringbloom4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -370,7 +370,7 @@ class IniFixBuilderFuncs():
                 ],
                 "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def ayakaSpringbloom5_7(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -401,7 +401,7 @@ class IniFixBuilderFuncs():
                 ],
                 "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def ayakaSpringbloom6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -434,7 +434,7 @@ class IniFixBuilderFuncs():
                     RegRemap({"dress": {**cls.IbTempToDrawIndexed}})
                 ],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def arlecchino5_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -461,7 +461,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def barbara4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -482,7 +482,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def barbara6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -505,7 +505,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def barbaraSummertime4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -526,7 +526,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def barbaraSummertime6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -549,7 +549,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def cherryHuTao5_3(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -626,7 +626,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def diluc6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -645,7 +645,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
                                       "body": {**cls.IbTempToDrawIndexed}})
                  ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def dilucFlamme4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -674,7 +674,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def dilucFlamme6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -697,7 +697,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
                                       "body": {**cls.IbTempToDrawIndexed}})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def fischl4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -720,7 +720,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def fischl6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -740,7 +740,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
                                       "body": {**cls.IbTempToDrawIndexed}})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def fischlHighness4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -771,7 +771,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}}),
                     RegNewVals({"dress": {"ib": "null"}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def fischlHighness6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -796,7 +796,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}}),
                     RegNewVals({"dress": {"ib": "null"}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyu4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -833,7 +833,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyu6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -860,7 +860,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyuTwilight4_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -896,7 +896,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyuTwilight6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -921,7 +921,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def hutao4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -979,7 +979,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.TexFXTempToRun},
                                       "dress": {**cls.TexFXTempToRun}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def hutao6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -1012,7 +1012,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.TexFXTempToRun},
                                       "dress": {**cls.TexFXTempToRun}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def jean4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:

--- a/Anime Game Remap (for all users)/apiMirror/pyproject.toml
+++ b/Anime Game Remap (for all users)/apiMirror/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "AnimeGameRemap"
-version = "4.6.3"
+version = "4.6.4"
 authors = [
   {name="NK", email="qqqqaaaapppp0000@gmail.com"},
   {name="Albert Gold", email="AlexXianZhenYuAu@gmail.com"}
@@ -18,7 +18,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-	"FixRaidenBoss2==4.6.3"
+	"FixRaidenBoss2==4.6.4"
 ]
 
 [project.urls]

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__init__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Sunday, February 15, 2026 01:10:55.805 PM UTC
-# Run Hash: e84ed157-9c5f-4f76-aeb3-6b027024d514
+# Datetime Ran: Wednesday, March 11, 2026 07:55:14.214 PM UTC
+# Run Hash: ab0f0ef6-6e4a-422e-bd4b-c9446326e6fb
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.6.3
+# Version: 4.6.4
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Sunday, February 15, 2026 01:10:55.805 PM UTC
-# Build Hash: a32bdf93-bb76-4095-b8f1-b09bcf8bfdab
+# Datetime Compiled: Wednesday, March 11, 2026 07:55:14.214 PM UTC
+# Build Hash: 1ab3b92e-ff8a-47cd-af7e-95e9a90142f0
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
+++ b/Anime Game Remap (for all users)/apiMirror/src/AnimeGameRemap/__main__.py
@@ -11,8 +11,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Sunday, February 15, 2026 01:10:55.805 PM UTC
-# Run Hash: e84ed157-9c5f-4f76-aeb3-6b027024d514
+# Datetime Ran: Wednesday, March 11, 2026 07:55:14.214 PM UTC
+# Run Hash: ab0f0ef6-6e4a-422e-bd4b-c9446326e6fb
 # 
 # **********************************
 # ================
@@ -30,10 +30,10 @@
 #
 # ***** AG Remap Stats *****
 #
-# Version: 4.6.3
+# Version: 4.6.4
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Sunday, February 15, 2026 01:10:55.805 PM UTC
-# Build Hash: a32bdf93-bb76-4095-b8f1-b09bcf8bfdab
+# Datetime Compiled: Wednesday, March 11, 2026 07:55:14.214 PM UTC
+# Build Hash: 1ab3b92e-ff8a-47cd-af7e-95e9a90142f0
 #
 # **************************
 #

--- a/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
+++ b/Anime Game Remap (for all users)/script build/src/FixRaidenBoss2/AGRemap.py
@@ -13,8 +13,8 @@
 #
 # Version: 1.0.0
 # Authors: Albert Gold#2696
-# Datetime Ran: Sunday, February 15, 2026 01:10:55.405 PM UTC
-# Run Hash: 809f4290-2849-4fdd-99dc-3c4d6b804e14
+# Datetime Ran: Wednesday, March 11, 2026 07:55:13.821 PM UTC
+# Run Hash: 3b75b054-a8f3-41a1-806d-5b7cf6f34b75
 # 
 # *******************************
 # ================
@@ -33,10 +33,10 @@
 #
 # ***** AG Remap Script Stats *****
 #
-# Version: 4.6.3
+# Version: 4.6.4
 # Authors: Albert Gold#2696, NK#1321
-# Datetime Compiled: Sunday, February 15, 2026 01:10:55.405 PM UTC
-# Build Hash: 61be42d7-22ca-4bc6-9448-d9103963415c
+# Datetime Compiled: Wednesday, March 11, 2026 07:55:13.821 PM UTC
+# Build Hash: feaca31f-6b27-460d-972f-29e4710dfc9a
 #
 # *********************************
 #
@@ -18668,7 +18668,7 @@ class IniFixBuilderFuncs():
                                                            "body": cls.IbDrawIndexedRename}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def amber6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18685,7 +18685,7 @@ class IniFixBuilderFuncs():
                                                           "body": cls.NNFixTempToRun}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def amberCN4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18700,7 +18700,7 @@ class IniFixBuilderFuncs():
                                                            "body": cls.IbDrawIndexedRename}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def amberCN6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18717,7 +18717,7 @@ class IniFixBuilderFuncs():
                                                           "body": cls.NNFixTempToRun}),
                                         RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                                           "body": cls.IbTempToDrawIndexed})],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ayaka4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18786,7 +18786,7 @@ class IniFixBuilderFuncs():
                                          "body": cls.IbTempToDrawIndexed,
                                          "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ayaka5_7(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18811,7 +18811,7 @@ class IniFixBuilderFuncs():
                                          "body": cls.IbTempToDrawIndexed,
                                          "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ayaka6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18835,7 +18835,7 @@ class IniFixBuilderFuncs():
                                          "body": {**cls.ORFixTempToRun, **cls.IbTempToDrawIndexed},
                                          "dress": {**cls.NNFixTempToRun, **cls.IbTempToDrawIndexed}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def ayakaSpringbloom4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18878,7 +18878,7 @@ class IniFixBuilderFuncs():
                 ],
                 "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def ayakaSpringbloom5_7(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18909,7 +18909,7 @@ class IniFixBuilderFuncs():
                 ],
                 "postRegEditFilters": [RegNewVals({"head": {"ib": "null"}})],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def ayakaSpringbloom6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18942,7 +18942,7 @@ class IniFixBuilderFuncs():
                     RegRemap({"dress": {**cls.IbTempToDrawIndexed}})
                 ],
                 "copyPreamble": IniComments.GIMIObjMergerPreamble.value,
-                "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def arlecchino5_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18969,7 +18969,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def barbara4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -18990,7 +18990,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def barbara6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19013,7 +19013,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def barbaraSummertime4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19034,7 +19034,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def barbaraSummertime6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19057,7 +19057,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
 
     @classmethod
     def cherryHuTao5_3(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19134,7 +19134,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                 ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def diluc6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19153,7 +19153,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
                                       "body": {**cls.IbTempToDrawIndexed}})
                  ],
-                 "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                 "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def dilucFlamme4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19182,7 +19182,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def dilucFlamme6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19205,7 +19205,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
                                       "body": {**cls.IbTempToDrawIndexed}})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def fischl4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19228,7 +19228,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": cls.IbTempToDrawIndexed,
                                       "body": cls.IbTempToDrawIndexed})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def fischl6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19248,7 +19248,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.IbTempToDrawIndexed},
                                       "body": {**cls.IbTempToDrawIndexed}})
                  ],
-                 "iniPostModelRegEditFilters": [[RegNewVals(vals = cls.IbHashToNull)], [RegNewVals(vals = cls.IbHashToNull)]]})
+                 "iniPostModelRegEditFilters": [[ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})], [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]]})
     
     @classmethod
     def fischlHighness4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19279,7 +19279,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}}),
                     RegNewVals({"dress": {"ib": "null"}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def fischlHighness6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19304,7 +19304,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {"ps-t3": ["ps-t2"]}}),
                     RegNewVals({"dress": {"ib": "null"}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyu4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19341,7 +19341,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyu6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19368,7 +19368,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyuTwilight4_4(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19404,7 +19404,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def ganyuTwilight6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19429,7 +19429,7 @@ class IniFixBuilderFuncs():
                                       "body": cls.IbTempToDrawIndexed,
                                       "dress": cls.IbTempToDrawIndexed})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def hutao4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19487,7 +19487,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.TexFXTempToRun},
                                       "dress": {**cls.TexFXTempToRun}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def hutao6_1(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:
@@ -19520,7 +19520,7 @@ class IniFixBuilderFuncs():
                     RegRemap(remap = {"head": {**cls.TexFXTempToRun},
                                       "dress": {**cls.TexFXTempToRun}})
                 ],
-                "postModelRegEditFilters": [RegNewVals(vals = cls.IbHashToNull)]})
+                "postModelRegEditFilters": [ RegRemove({IniKeywords.Ib.value: {"drawindexed"}})]})
     
     @classmethod
     def jean4_0(cls) -> Tuple[BaseIniFixer, List[Any], Dict[str, Any]]:

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/RemapFixLog.txt
@@ -6,23 +6,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -94,7 +94,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -102,27 +102,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -170,20 +170,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -201,7 +201,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -209,27 +209,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fixAllModsFixOnlyInisUndoed_fixedAllMods/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/RemapFixLog.txt
@@ -29,7 +29,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -37,27 +37,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -92,7 +92,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -100,27 +100,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixAllModsFixOnly_fixAllMods/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackups_fixModsWithoutBackups/Logs/RemapFixLog.txt
@@ -56,23 +56,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -144,7 +144,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -152,27 +152,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -205,20 +205,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -237,7 +237,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -245,27 +245,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsNoBackups/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_fullFixNoBackupsallMods_fixAllModsNoBackups/Logs/RemapFixLog.txt
@@ -56,23 +56,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -144,7 +144,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -152,27 +152,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -221,20 +221,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -253,7 +253,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -261,27 +261,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigAndUndoFix_filesSameAsBefore/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/RemapFixLog.txt
@@ -29,7 +29,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -37,27 +37,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -88,7 +88,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -96,27 +96,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/prevLog/RemapFixLog.txt
+++ b/Testing/Integration Tester/IntegrationTester/Tests/MixedModsTests/expected_hideOrigNotBackups_noBackupsOnyRemap/Logs/prevLog/RemapFixLog.txt
@@ -57,23 +57,23 @@
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
 # Mods/Ei/Raiden/Body/Center --> 
 # Mods/Ei/Raiden/Body/Center --> Traceback (most recent call last):
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ei/Raiden/Body/Center -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ei/Raiden/Body/Center -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ei/Raiden/Body/Center -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ei/Raiden/Body/Center -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ei/Raiden/Body/Center -->     blend = BlendFile(blendFile)
 # Mods/Ei/Raiden/Body/Center -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ei/Raiden/Body/Center -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ei/Raiden/Body/Center -->     self.read()
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 144, in read
 # Mods/Ei/Raiden/Body/Center -->     self._data = FileService.readBinary(self.src)
 # Mods/Ei/Raiden/Body/Center -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
+# Mods/Ei/Raiden/Body/Center -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/tools/files/FileService.py", line 511, in readBinary
 # Mods/Ei/Raiden/Body/Center -->     with open(src, "rb") as f:
 # Mods/Ei/Raiden/Body/Center -->          ^^^^^^^^^^^^^^^
 # Mods/Ei/Raiden/Body/Center --> FileNotFoundError: [Errno 2] No such file or directory: 'absolute/path/Mods/Ei/Raiden/Body/whoopsIReferencedTheWrongThing.buf'
@@ -151,7 +151,7 @@
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino/Ugly -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino/Ugly -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino/Ugly --> KeyError: 'glitchedOutResource'
@@ -159,27 +159,27 @@
 # Mods/Arlecchino/Ugly --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino/Ugly --> 
 # Mods/Arlecchino/Ugly --> Traceback (most recent call last):
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino/Ugly -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino/Ugly -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino/Ugly -->     parser.parse()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino/Ugly -->     self.parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino/Ugly -->     super().parseResources()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino/Ugly -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino/Ugly -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino/Ugly -->     self.construct()
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino/Ugly -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino/Ugly -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino/Ugly -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino/Ugly -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino/Ugly --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino/Ugly --> 
@@ -233,20 +233,20 @@
 # Mods/Ayaka --> BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
 # Mods/Ayaka --> Traceback (most recent call last):
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1114, in correctResource
 # Mods/Ayaka -->     correctedResourcePath = correctFile(origFullPath, fixedFullPath, modType, modName, partIndex, i, self.version, model, resourceStats)
 # Mods/Ayaka -->                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 1406, in <lambda>
 # Mods/Ayaka -->     lambda origFullPath,  fixedFullPath, modType, modName, partInd, pathInd, version, iniResourceModel, resourceStats: self.blendCorrection(origFullPath, modType, modName, fixedBlendFile = fixedFullPath, version = version),
 # Mods/Ayaka -->                                                                                                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/Mod.py", line 782, in blendCorrection
 # Mods/Ayaka -->     blend = BlendFile(blendFile)
 # Mods/Ayaka -->             ^^^^^^^^^^^^^^^^^^^^
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BlendFile.py", line 52, in __init__
 # Mods/Ayaka -->     super().__init__(src, [BufElementTypes.BlendWeightFloatRGBA.value, BufElementTypes.BlendIndicesIntRGBA.value], fileType = "Blend.buf")
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 64, in __init__
 # Mods/Ayaka -->     self.read()
-# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
+# Mods/Ayaka -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/BufFile.py", line 148, in read
 # Mods/Ayaka -->     raise BufFileNotRecognized(self.src, fileType = self.fileType)
 # Mods/Ayaka --> src.FixRaidenBoss2.exceptions.BufFileNotRecognized.BufFileNotRecognized: ERROR: Blend.buf file format not recognized for ayakaBlend.buf at absolute/path/Mods/Ayaka
 # Mods/Ayaka --> 
@@ -267,7 +267,7 @@
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 250, in getSection
 # Mods/Arlecchino -->     ifTemplate = self._allSections[sectionName]
 # Mods/Arlecchino -->                  ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
 # Mods/Arlecchino --> KeyError: 'glitchedOutResource'
@@ -275,27 +275,27 @@
 # Mods/Arlecchino --> The above exception was the direct cause of the following exception:
 # Mods/Arlecchino --> 
 # Mods/Arlecchino --> Traceback (most recent call last):
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 731, in fixMod
 # Mods/Arlecchino -->     iniIsFixed = self.fixIni(ini, mod, flushIfTemplates = True)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/remapService.py", line 646, in fixIni
 # Mods/Arlecchino -->     ini.parse(flushIfTemplates = flushIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/files/IniFile.py", line 2961, in parse
 # Mods/Arlecchino -->     parser.parse()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 431, in parse
 # Mods/Arlecchino -->     self.parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIObjParser.py", line 352, in parseResources
 # Mods/Arlecchino -->     super().parseResources()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 397, in parseResources
 # Mods/Arlecchino -->     self._parseElementResources(self.blendCommandsGraph, self.blendResourceCommandsGraph,
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/strategies/iniParsers/GIMIParser.py", line 311, in _parseElementResources
 # Mods/Arlecchino -->     resourceGraph.build(newTargetSections = resourceCommandLst, newAllSections = self._iniFile.sectionIfTemplates)
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 220, in build
 # Mods/Arlecchino -->     self.construct()
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 312, in construct
 # Mods/Arlecchino -->     ifTemplate = self.getSection(sectionName)
 # Mods/Arlecchino -->                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/REpos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
+# Mods/Arlecchino -->   File "/mnt/c/Users/AlexX/Documents/Games/Mods/Repos/Anime-Game-Remap/Testing/Integration Tester/../../Anime Game Remap (for all users)/api/src/FixRaidenBoss2/model/IniSectionGraph.py", line 253, in getSection
 # Mods/Arlecchino -->     raise KeyError(f"The section by the name '{sectionName}' does not exist") from e
 # Mods/Arlecchino --> KeyError: "The section by the name 'glitchedOutResource' does not exist"
 # Mods/Arlecchino --> 

--- a/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
+++ b/Tools/Utilities/src/AGRemapUtils/Utils/constants/toolStats.py
@@ -4,7 +4,7 @@ from ..softwareStats.SoftwareContributor import SoftwareContributor
 
 Title = "Anime Game Remap"
 ShortTitle = "AG Remap"
-APIVersion = "4.6.3"
+APIVersion = "4.6.4"
 
 Authors = {
     "Albert": SoftwareContributor("Albert Gold", discName = "albertgold", oldDisName = "Albert Gold#2696"),


### PR DESCRIPTION
- For remapped mods, extra textures added by TexFx seem to show a bunch of triangle, similar to the [.ib issue since GI 5.x](https://github.com/nhok0169/Anime-Game-Remap/pull/160). The original solution was to simply disable the entire global IB handling by setting the `hash` of the section to `null`. But this method still leaves some lingering data that conflicts with TexFx. A better way would be to remove all `drawindexed` calls and keep the `handling = skip` option